### PR TITLE
Solve error could not find a valid gem rogue-4.2.1

### DIFF
--- a/bin/install-asciidoctor.sh
+++ b/bin/install-asciidoctor.sh
@@ -159,7 +159,7 @@ git clone https://github.com/rouge-ruby/rouge
 cd rouge
 git log -n 1 | cat
 gem build rouge.gemspec
-gem install rouge-4.2.1.gem
+gem install rouge-4.3.0.gem
 
 which ruby
 ruby --version


### PR DESCRIPTION
I aligned my repo with the latest version, but I encountered an error during installation. I resolved it with this patch.
![error](https://github.com/user-attachments/assets/d952cdb3-6f40-4361-8b0d-547af875acca)
