### PR TITLE
Finish Asciidoc syntax adaptation

### DIFF
--- a/bin/install-asciidoctor.sh
+++ b/bin/install-asciidoctor.sh
@@ -160,7 +160,8 @@ cd rouge
 git log -n 1 | cat
 gem build rouge.gemspec
 gem install rouge-4.3.0.gem
- gem install asciidoctor-bibtex
+gem install asciidoctor-bibtex
+gem install asciidoctor-lists
 
 which ruby
 ruby --version

--- a/p4-spec-next/P4-16-spec.adoc
+++ b/p4-spec-next/P4-16-spec.adoc
@@ -8,6 +8,7 @@
 :toc: macro
 :toc-title: Contents
 :toclevels: 5
+:toc: left
 :!chapter-signifier:
 :xrefstyle: short
 :stem: latexmath

--- a/p4runtime-spec-next/Makefile
+++ b/p4runtime-spec-next/Makefile
@@ -7,7 +7,7 @@ ROUGE_CSS= style
 all: ${SPEC}.pdf ${SPEC}.html
 
 ${SPEC}.pdf: ${SPEC}.adoc
-	time asciidoctor-pdf -a pdf-fontsdir=resources/fonts -v -r asciidoctor-mathematical -r asciidoctor-bibtex -a rouge-style=$(ROUGE_STYLE) $<
+	time asciidoctor-pdf -a pdf-fontsdir=resources/fonts -v -r asciidoctor-mathematical -r asciidoctor-bibtex -r asciidoctor-lists -a rouge-style=$(ROUGE_STYLE) $<
 
 ${SPEC}.html: ${SPEC}.adoc 
 	time asciidoctor -v -r asciidoctor-mathematical -a rouge-css=$(ROUGE_CSS) $<

--- a/p4runtime-spec-next/Makefile
+++ b/p4runtime-spec-next/Makefile
@@ -10,7 +10,7 @@ ${SPEC}.pdf: ${SPEC}.adoc
 	time asciidoctor-pdf -a pdf-fontsdir=resources/fonts -v -r asciidoctor-mathematical -r asciidoctor-bibtex -r asciidoctor-lists -a rouge-style=$(ROUGE_STYLE) $<
 
 ${SPEC}.html: ${SPEC}.adoc 
-	time asciidoctor -v -r asciidoctor-mathematical -a rouge-css=$(ROUGE_CSS) $<
+	time asciidoctor -v -r asciidoctor-mathematical -r asciidoctor-bibtex -r asciidoctor-lists -a rouge-css=$(ROUGE_CSS) $<
 
 clean:
 	/bin/rm -f ${SPEC}.pdf ${SPEC}.html resources/figs/stem-*.png

--- a/p4runtime-spec-next/P4Runtime-Spec.adoc
+++ b/p4runtime-spec-next/P4Runtime-Spec.adoc
@@ -8,6 +8,7 @@
 :toc: macro
 :toc-title: Contents
 :toclevels: 5
+:toc: left
 :!chapter-signifier:
 :xrefstyle: short
 :stem: latexmath
@@ -790,6 +791,7 @@ components.
 
 These messages appear nested within many other messages.
 
+[#sec-documentation-message]
 ==== `Documentation` Message
 
 `Documentation` is used to carry both brief and long descriptions of something.
@@ -807,6 +809,7 @@ message Documentation {
 }
 ----
 
+[#sec-preamble-message]
 ==== `Preamble` Message
 
 The preamble serves as the "descriptor" for each entity and contains the unique
@@ -1079,6 +1082,7 @@ be found in the following place:
   an optional field `SourceLocation source_location` holding its source
   location, if present.
 
+[#sec-pkginfo-message]
 === `PkgInfo` Message
 
 The `PkgInfo` message contains package-level metadata which describes the
@@ -1335,7 +1339,7 @@ control plane. This message contains the following fields:
 
     ** `doc`, a `Documentation` message describing this match field.
 
-    ** `type_name`, which indicates whether the match field has a xref:sec-user-defined-types[user-definedtype]; this is useful for xref:sec-psa-metadata-translation[translation].
+    ** `type_name`, which indicates whether the match field has a xref:sec-user-defined-types[user-defined type]; this is useful for xref:sec-psa-metadata-translation[translation].
 
 * `action_refs`, a repeated `ActionRef` field representing the set of possible
   actions for this table. The `ActionRef` message is used to reference an action
@@ -1540,6 +1544,7 @@ For indexed counters, the `Counter` message contains also an `index_type_name`
 field, which indicates whether the index has a xref:sec-user-defined-types[user-defined
 type]. This is useful for xref:sec-psa-metadata-translation[translation].The underlying built-in type must be a fixed-width unsigned bitstring (`bit<W>`).
 
+[#sec-meter-directmeter]
 === `Meter` & `DirectMeter`
 
 `Meter` and `DirectMeter` messages are used to specify all possible instances of
@@ -1652,7 +1657,7 @@ message contains the following fields:
       annotation associated to this metadata.
     ** `bitwidth`, an `int32` representing the size in bits of this metadata.
     ** `type_name`, which indicates whether the metadata field has a 
-        xref:sec-user-defined-type[user-defined type]; this is useful for
+        xref:sec-user-defined-types[user-defined type]; this is useful for
         xref:sec-psa-metadata-translation[translation].
 
 As an example, consider the following snippet of a P4 program where controller

--- a/p4runtime-spec-next/P4Runtime-Spec.adoc
+++ b/p4runtime-spec-next/P4Runtime-Spec.adoc
@@ -6452,12 +6452,12 @@ properties, but we may include on in future versions of the API.
   in particular, there is no way for a client to query the supported minor +
   patch version numbers.
 
-[@h1:"A"]
-=== Appendix 
+[appendix]
+= Appendix 
 
-==== Revision History
+=== Revision History
 
-===== Changes in v1.4.0
+==== Changes in v1.4.0
 
 * Add a `Type` field to the `MeterSpec` message allowing users to restrict the
   type of meters that can be used for a table and a new `eburst` field to the
@@ -6494,7 +6494,7 @@ properties, but we may include on in future versions of the API.
 * Add a `selector_size_semantics` field to the `ActionProfile` message
   in P4Info.
 
-===== Changes in v1.3.0
+==== Changes in v1.3.0
 
 * Add IANA assigned TCP port, 9559, to P4Runtime server discussion.
 * Move "Security considerations" section to P4Runtime server discussion.
@@ -6505,7 +6505,7 @@ properties, but we may include on in future versions of the API.
 * Clarify that source locations for annotations are optional in the P4Info
   message.
 
-===== Changes in v1.2.0
+==== Changes in v1.2.0
 
 * Add new `OPTIONAL` match kind. At the moment, `OPTIONAL` is only supported by
   the v1model architecture cite:[v1model], and not by PSA. It will eventually be
@@ -6525,7 +6525,7 @@ properties, but we may include on in future versions of the API.
 * Add optional P4 source locations to both structured and unstructured
   annotations.
 
-===== Changes in v1.1.0
+==== Changes in v1.1.0
 
 * Major overhaul of master-arbitration: while the Protobuf messages did not
   change, the state machine that the server needs to implement is significantly
@@ -6550,7 +6550,7 @@ properties, but we may include on in future versions of the API.
 * Document that `@p4runtime_translation` need only be supported when applied to
   type declarations in P4.
 
-==== P4 Annotations
+=== P4 Annotations
 
 Table <<#tab-p4-annotations>> lists P4~16~ annotations introduced primarily for
 the purpose of adding features for the P4Runtime API.
@@ -6576,7 +6576,7 @@ the purpose of adding features for the P4Runtime API.
 |===
 
 [#sec-value-set-example]
-=== A More Complex Value Set Example 
+==== A More Complex Value Set Example 
 
 This section includes a more complex Value Set example, with multiple matches of
 different kinds.

--- a/p4runtime-spec-next/P4Runtime-Spec.adoc
+++ b/p4runtime-spec-next/P4Runtime-Spec.adoc
@@ -611,7 +611,7 @@ leave the `role` unset.
 === Role Config
 
 The `role.config` field in the `MasterArbitrationUpdate` message sent by the
-controller describes the role configuration, &ie; which operations are in the
+controller describes the role configuration, i.e. which operations are in the
 scope of a given role. In particular, the definition of a role may include the
 following:
 
@@ -2335,9 +2335,9 @@ If the string's byte length is zero, the server always rejects the string.
 When the server rejects a binary string due to any of the previous criteria,
 it returns an `OUT_OF_RANGE` error.
 
-For all binary strings, P4Runtime uses big-endian (&ie; network) byte-order.
+For all binary strings, P4Runtime uses big-endian (i.e. network) byte-order.
 For signed integer values (`int<W>` P4 type), P4Runtime uses the same two's
-complement bitwise representation as P4. Table [#tab-valid-bytestring-encoding]
+complement bitwise representation as P4. Table <<#tab-valid-bytestring-encoding>>
 shows various examples of integer values that the server accepts as valid
 P4Runtime binary strings according to the criteria in the list above.
 
@@ -3269,7 +3269,7 @@ Every P4 table falls into one of three categories:
 * *Normal table*: Neither `entries` nor `const entries` are declared
   in the source code, and thus `is_const_table` and
   `has_initial_entries` will both be false.  A corner case is that if
-  it has `entries = { }` with no `const` before `entries`, &ie; an
+  it has `entries = { }` with no `const` before `entries`, i.e. an
   empty list of entries, that is also a normal table.
 * *Constant table*: The table has `const entries` declared, and thus a
   separate `entries` property is not permitted by the language.  Such
@@ -5099,7 +5099,7 @@ An update can be one of the following types:
   container is already full, a `RESOURCE_EXHAUSTED` error is returned.
 
 * `MODIFY`: Modifies the P4 entity to its new specified state. This uses
-  *assign* or *full-snapshot* semantics, &ie; the entity field contains the
+  *assign* or *full-snapshot* semantics, i.e. the entity field contains the
   complete new state of the entity, not a diff from its previous state. If the
   entity is malformed, an `INVALID_ARGUMENT` error is usually returned (unless a
   more specific error code applies cite:[gRPCStatusCodes]). If the entity does not
@@ -6004,7 +6004,7 @@ translated types which are not declared as part of the PSA architecture.
 
 .P4Runtime Metadata Translation for the Portable Switch Architecture
 [#fig-psa-metadata-translation]
-image::psa-metadata-translation..png[]
+image::psa-metadata-translation.png[]
 
 Figure <<#fig-psa-metadata-translation>> illustrates a motivating example,
 where a centralized controller is controlling two P4Runtime targets in a fabric.
@@ -6555,27 +6555,25 @@ properties, but we may include on in future versions of the API.
 Table <<#tab-p4-annotations>> lists P4~16~ annotations introduced primarily for
 the purpose of adding features for the P4Runtime API.
 
-~ TableFigure { #tab-p4-annotations; \
-    caption: "P4 annotations introduced by P4Runtime"; \
-    page-align: forcehere; }
-|--------------------------  |---------------------------------------|
-| Annotation                 | Description                           |
-+----------------------------+---------------------------------------+
-| `@brief`                   | See section [#sec-annotating-p4-entities-with-documentation] |
-| `@controller_header`       | See section [#sec-controller-packet-meta] |
-| `@description`             | See section [#sec-annotating-p4-entities-with-documentation] |
-| `@id`                      | See section [#sec-id-allocation] |
-| `@max_group_size`          | See sections [#sec-p4info-action-profile], [#sec-action-profile-group-programming] |
-| `@selector_size_semantics` | See section [#sec-p4info-action-profile] |
-| `@max_member_weight`       | See section [#sec-p4info-action-profile] |
-| `@two_rate_three_color`    | See section [#sec-meter-directmeter] |
-| `@single_rate_three_color` | See section [#sec-meter-directmeter] |
-| `@single_rate_two_color`   | See section [#sec-meter-directmeter] |
-| `@pkginfo`                 | See section [#sec-annotating-p4-code-with-pkginfo] |
-| `@platform_property`       | See section [#sec-annotating-p4-code-with-pkginfo] |
-| `@p4runtime_translation`   | See sections [#sec-user-defined-types], [#sec-translation-of-port-numbers] |
-+----------------------------+---------------------------------------+
-~
+.Example of statically-assigned P4Info object IDs
+[cols="2",width=80%, align=center, options=header, unbreakable]
+[#tab-p4-annotations]
+|===
+| Annotation                 | Description                           
+| `@brief`                   | See section <<#sec-annotating-p4-entities-with-documentation>> 
+| `@controller_header`       | See section <<#sec-controller-packet-meta>>
+| `@description`             | See section <<#sec-annotating-p4-entities-with-documentation>> 
+| `@id`                      | See section <<#sec-id-allocation>>
+| `@max_group_size`          | See sections <<#sec-p4info-action-profile>>, <<#sec-action-profile-group-programming>>
+| `@selector_size_semantics` | See section <<#sec-p4info-action-profile>> 
+| `@max_member_weight`       | See section <<#sec-p4info-action-profile>>
+| `@two_rate_three_color`    | See section <<#sec-meter-directmeter>>
+| `@single_rate_three_color` | See section <<#sec-meter-directmeter>>
+| `@single_rate_two_color`   | See section <<#sec-meter-directmeter>>
+| `@pkginfo`                 | See section <<#sec-annotating-p4-code-with-pkginfo>> 
+| `@platform_property`       | See section <<#sec-annotating-p4-code-with-pkginfo>> 
+| `@p4runtime_translation`   | See sections <<#sec-user-defined-types>>, <<#sec-translation-of-port-numbers>> 
+|===
 
 [#sec-value-set-example]
 === A More Complex Value Set Example 
@@ -6689,12 +6687,13 @@ channel.  As a rule of thumb, it might make sense to allow for at least
 `8192 + MAX_UPDATES_PER_WRITE * 100` bytes of metadata.
 
 For example, in C++, one can create a client channel as follows:
-~ Begin CPP
+[source,cpp]
+----
 const int MAX_UPDATES_PER_WRITE = 100;
 ::grpc::ChannelArguments arguments;
 arguments.SetInt(GRPC_ARG_MAX_METADATA_SIZE, 8192 + MAX_UPDATES_PER_WRITE*100);
 return grpc::CreateCustomChannel(address, credentials, arguments);
-~ End CPP
+----
 
 ==== gRPC Server Maximum Receive Message Size
 

--- a/p4runtime-spec-next/P4Runtime-Spec.adoc
+++ b/p4runtime-spec-next/P4Runtime-Spec.adoc
@@ -19,6 +19,7 @@
 :bibtex-file: resources/theme/references.bib
 :bibtex-order: appearance
 :bibtex-style: ieee
+:listing-caption: Listing
 
 
 [abstract]
@@ -31,9 +32,13 @@ document includes developers who want to write controller applications for P4
 devices or switches.
 
 toc::[]
-//add toc od figures
-//add toc of table
+:sectnums!:
+== List of figures
+list-of::image[]
 
+== List of tables
+list-of::table[]
+:sectnums:
 
 [#sec-scope]
 == Introduction and Scope
@@ -211,7 +216,7 @@ The following are not in scope of this specification document:
 [#sec-reference-architecture]
 == Reference Architecture 
 
-Figure <<#fig-reference-arch>> represents the P4Runtime Reference
+Figure <<#fig-reference-architecture>> represents the P4Runtime Reference
 Architecture. The device or target to be controlled is at the bottom, and one or
 more controllers is shown at the top. P4Runtime only grants write access to a
 single primary controller for each read/write entity. A role defines a grouping
@@ -300,6 +305,7 @@ controller can also query the `ForwardingPipelineConfig` from the target via the
 configuration from a running device to synchronize the controller to its current
 state.
 
+[#sec-p4-as-behavioral-description-language]
 === P4 as a Behavioral Description Language 
 
 P4 can be considered a behavioral description of a switching device which may or
@@ -355,10 +361,10 @@ number of reasons, the most likely of which are:
 2. The target was not implemented using P4 code to begin with, although it still
    obeys the control plane API specified in the P4Info.
 
-As discussed in Section <<sec-p4-as-behavioral-description-language>>, in the
+As discussed in Section <<#sec-p4-as-behavioral-description-language>>, in the
 absence of a P4 program describing the data plane behavior, the detailed
 knowledge required to write correct control plane code must come from other
-sources, &eg; documentation.
+sources, e.g. documentation.
 
 [#sec-partial-p4info]
 ==== Partial P4Info and P4 Source are Available
@@ -377,7 +383,7 @@ In this situation, P4Info is selectively packaged into role-based subsets to
 allow some controllers access to just the functionality required. For example, a
 controller may only need read access to statistics counters and nothing more.
 
-
+[#sec-restarts]
 === P4Runtime State Across Restarts 
 
 All targets support full restarts, where all forwarding state is reset and the
@@ -390,14 +396,14 @@ may have the ability to access information from memory before the upgrade.
 == Controller Use-cases
 
 P4Runtime allows for more than one controller. The mechanisms and semantics are
-described in a later<<sec-client-arbitration>>. Here we
+described in a later<<#sec-client-arbitration-and-controller-replication>>. Here we
 present a number of use-cases. Each use-case highlights a particular aspect of
 P4Runtime's flexibility and is not intended to be exhaustive. Real-world
 use-cases may combine various techniques and be more complex.
 
 === Single Embedded Controller
 
-Figure <<fig-single-embedded-controller]>> shows perhaps the simplest use-case. A
+Figure <<#fig-single-embedded-controller>> shows perhaps the simplest use-case. A
 device or target has an embedded controller which communicates to an on-board
 switch via P4Runtime. This might be appropriate for an embedded appliance which
 is not intended for SDN use-cases.
@@ -447,7 +453,7 @@ image::embedded-plus-single-remote-controller.png[]
 Figure <<fig-embedded-plus-two-remote-controllers>> illustrates the case of an
 embedded controller similar to the previous use-case, and two remote
 controllers. One of the remote controllers is responsible for some entities,
-&eg; routing tables, and the other remote controller is responsible for other
+e.g. routing tables, and the other remote controller is responsible for other
 entities, perhaps statistics tables. Role-based access divides the ownership.
 
 .Use-Case: Embedded Plus Two Remote Controllers
@@ -1184,7 +1190,7 @@ Above we see several different types of annotations:
 
 Declaring one or more of these annotations on `main` will
 generate a single corresponding `PkgInfo` message in the P4Info as described in
-xref:#sec-pkginfo-message[PkgInfo Message].
+xref:sec-pkginfo-message[PkgInfo Message].
 
 The following example shows `@pkginfo` annotations using a mixture of single and
 multiple key-value pairs. It also shows `@brief` and `@description` annotations,
@@ -1646,7 +1652,7 @@ message contains the following fields:
       annotation associated to this metadata.
     ** `bitwidth`, an `int32` representing the size in bits of this metadata.
     ** `type_name`, which indicates whether the metadata field has a 
-        xref:sec-user-defined-typee[user-defined type]; this is useful for
+        xref:sec-user-defined-type[user-defined type]; this is useful for
         xref:sec-psa-metadata-translation[translation].
 
 As an example, consider the following snippet of a P4 program where controller
@@ -2783,7 +2789,7 @@ type_info {
 ----
 
 Note that a P4 compiler may provide a mechanism external to the language to
-specify if and how a user-defined type is to be translated (&eg; through some
+specify if and how a user-defined type is to be translated (e.g. through some
 configuration file passed on the command-line when invoking the compiler). This
 mechanism should take precedence over `@p4runtime_translation` to enable users
 to overwrite annotations included as part of the P4 architecture definition.
@@ -3349,7 +3355,8 @@ fields may be used to select and filter results:
 For example, in order to read all entries from all tables from device 3, the
 client can use the following `ReadRequest` message.
 
-~ Begin Prototext
+[source,proto]
+----
 device_id: 3
 entities {
   table_entry {
@@ -3359,13 +3366,14 @@ entities {
     metadata: ""
   }
 }
-~ End Prototext
+----
 
 In order to read all entries with priority 11 from a specific table (with id
 0x0212ab34) from device 3, the client can use the following `ReadRequest`
 message:
 
-~ Begin Prototext
+[source,proto]
+----
 device_id: 3
 entities {
   table_entry {
@@ -3375,22 +3383,23 @@ entities {
     metadata: ""
   }
 }
-~ End Prototext
+----
 
 The canonical representation of "don't care" matches, combined with the ability
 to do a wildcard read on all table entries by leaving the `match` field unset,
 means that there exists a specific ambiguous case in which the same message
 could be used to either read a single "don't care" entry or to do a wildcard
 read. If a table has no fields with match kind `EXACT`, it is possible via
-P4Runtime to add an entry that is "don't care" for all fields (&ie; has an empty
-`match` field) but is not the default entry (&ie; `is_default_action` is
+P4Runtime to add an entry that is "don't care" for all fields (i.e. has an empty
+`match` field) but is not the default entry (i.e. `is_default_action` is
 false). When reading this entry from the table, there is no way to read *only*
 that entry from the table, because it would require providing an unset `match`
 field in the request, which in turn indicates that the client wishes to perform
 a wildcard read on all non-default entries. Consider the following example which
 uses a table with a single `LPM` match:
 
-~ Begin P4Example
+[source,p4]
+----
 table t {
   key = {
     hdr.ipv4.dip: lpm;
@@ -3399,10 +3408,12 @@ table t {
     drop; fwd;
   }
 }
-~ End P4Example
+----
 
 The following `WriteRequest` message can be used to add 2 entries:
-~ Begin Prototext
+
+[source,proto]
+----
 device_id: 3
 entities {
   table_entry { # don't care entry
@@ -3420,33 +3431,35 @@ entities {
     # ...
   }
 }
-~ End Prototext
+----
 
 The first entry is a "don't care" entry, while the second one matches all
 `10.0.0.0/8` addresses. The second entry has higher priority than the first one.
 
 The following `ReadRequest` message will return *all* entries in the table, not
 just the "don't care" entry.
-~ Begin Prototext
+[source,proto]
+----
 device_id: 3
 entities {
   table_entry {
     table_id: 0x0212ab34
   }
 }
-~ End Prototext
+----
 
 This issue also exists for tables with `TERNARY`, `RANGE`, and `OPTIONAL`
 matches. However, in this case the priority is also taken into account for
 wildcard reads, and because a priority of 0 is not valid, in practice only the
 entries with the same priority as the "don't care" entry will be returned to the
 client. If the client uses distinct priority values for all entries --- which is
-strongly recommended to achieve [deterministic behavior](#sec-table-entry) ---,
+strongly recommended to achieve xref:sec-table-entry[deterministic behavior] ---,
 then there is no ambiguity because the wildcard read will actually return a
 single entry (the "don't care" entry) as long as the `priority` field is set to
 the correct value.
 
-### Direct Resources { #sec-direct-resources}
+[#sec-direct-resources]
+=== Direct Resources 
 
 In addition to the `DirectCounterEntry` and `DirectMeterEntry` entities,
 P4Runtime support reading and writing direct resources as part of the
@@ -3483,62 +3496,62 @@ give the P4Runtime client fined-grained control over how direct resources are
 read and written through the `TableEntry` message. The list below describes how
 the server must handle the `meter_config`, `counter_data` and
 `meter_counter_data` fields for read and write requests, based on whether the
-fields are set or not. We do not cover error cases in the list, &ie; we assume
+fields are set or not. We do not cover error cases in the list, i.e. we assume
 that we are dealing with a table which is assigned a direct counter / a direct
 meter, and that the action being used for the table entry "executes" the direct
 resource appropriately.
 
 * `meter_config` field
-    * `WriteRequest (INSERT)`
-        * if **unset**: The initial configuration for the meter entry is the
+    ** `WriteRequest (INSERT)`
+        *** if **unset**: The initial configuration for the meter entry is the
           default (meter returns GREEN for all packets).
-        * if **set**: The initial configuration for the meter entry is the one
+        *** if **set**: The initial configuration for the meter entry is the one
           provided by the client.
-    * `WriteRequest (MODIFY)`
-        * if **unset**: The meter entry's configuration is reset to the default
+    ** `WriteRequest (MODIFY)`
+        *** if **unset**: The meter entry's configuration is reset to the default
           (meter returns GREEN for all packets).
-        * if **set**: The value provided by the client is used to re-configure
+        *** if **set**: The value provided by the client is used to re-configure
           the meter entry.
-    * `ReadRequest`
-        * if **unset**: The response does not include the meter entry's
+    ** `ReadRequest`
+        *** if **unset**: The response does not include the meter entry's
           configuration (`meter_config` is unset in the response).
-        * if **set**: If the meter entry's configuration is the default
+        *** if **set**: If the meter entry's configuration is the default
           configuration, `meter_config` is unset in the response. Otherwise, the
           response includes the meter entry's configuration that was written by
           the client earlier. This respects the "read-write symmetry" principle.
 
 * `counter_data` field
-    * `WriteRequest (INSERT)`
-        * if **unset**: The initial value for the counter entry is the default
+    ** `WriteRequest (INSERT)`
+        *** if **unset**: The initial value for the counter entry is the default
           (0).
-        * if **set**: The initial value for the counter entry is the one
+        *** if **set**: The initial value for the counter entry is the one
           provided by the client.
-    * `WriteRequest (MODIFY)`
-        * if **unset**: The counter entry's value is not changed.
-        * if **set**: The value provided by the client is written to the counter
+    ** `WriteRequest (MODIFY)`
+        *** if **unset**: The counter entry's value is not changed.
+        *** if **set**: The value provided by the client is written to the counter
           entry.
-    * `ReadRequest`
-        * if **unset**: The response does not include the counter entry's value
+    ** `ReadRequest`
+        *** if **unset**: The response does not include the counter entry's value
           (`counter_data` is unset in the response).
-        * if **set**: The response includes the counter entry's value read from
+        *** if **set**: The response includes the counter entry's value read from
           the target.
 
 * `meter_counter_data` field
-    * `WriteRequest (INSERT)`
-        * if **unset**: The initial value for all 3 counter entries is the
+    ** `WriteRequest (INSERT)`
+        *** if **unset**: The initial value for all 3 counter entries is the
           default (0).
-        * if **set**: The initial value for all 3 counter entries is the
+        *** if **set**: The initial value for all 3 counter entries is the
 	  default (0). Sub-field, if any, can only have zero (0) as its value.
 	  `INVALID_ARGUMENT` error is returned for any non-zero sub-field value.
-    * `WriteRequest (MODIFY)`
-        * if **unset**: All the 3 counter entries are unchanged.
-        * if **set**: All the 3 counters are reset to 0. Sub-field, if any, can
+    ** `WriteRequest (MODIFY)`
+        *** if **unset**: All the 3 counter entries are unchanged.
+        *** if **set**: All the 3 counters are reset to 0. Sub-field, if any, can
 	  only have zero (0) as its value. `INVALID_ARGUMENT` error is returned
 	  for any non-zero sub-field value.
-    * `ReadRequest`
-        * if **unset**: The response does not include counter values
+    ** `ReadRequest`
+        *** if **unset**: The response does not include counter values
           (`meter_counter_data` is unset in the response).
-        * if **set**: The response includes all the 3 counter values read from
+        *** if **set**: The response includes all the 3 counter values read from
           the target.
 
 In its default configuration, a meter returns the GREEN color for every packet
@@ -3546,13 +3559,14 @@ when it is executed. This default configuration can be achieved by leaving the
 `meter_config` field unset when inserting **or modifying** a table entry. When
 modifying a table entry, if the P4Runtime client wishes to maintain the same
 meter configuration, it needs to be provided again in the `TableEntry` message
-(&ie; the `meter_config` field must be set to match the existing configuration).
+(i.e. the `meter_config` field must be set to match the existing configuration).
 
-### Idle-timeout { #sec-idle-timeout }
+[#sec-idle-timeout]
+=== Idle-timeout 
 
 P4Runtime supports idle timeout for table entries. When adding a table entry,
 the client can specify a Time-To-Live (TTL) value. If at any time during its
-lifetime, the data plane entry is not "hit" (&ie; not selected by any packet
+lifetime, the data plane entry is not "hit" (i.e. not selected by any packet
 lookup) for a lapse of time greater or equal to its TTL, the P4Runtime should,
 with best effort, generate a stream notification --- using the
 `IdleTimeoutNotification` message --- to the primary client, which can then take
@@ -3562,7 +3576,7 @@ Two fields of the `TableEntry` Protobuf message are used to implement idle
 timeout:
 
 * `idle_timeout_ns`: the configured TTL for the table entry in nanoseconds. A
-  value of 0 means that the entry never expires, &ie; no
+  value of 0 means that the entry never expires, i.e. no
   `IdleTimeoutNotification` message will ever be generated for this entry. When
   a client reads a `TableEntry`, this field will be included in the response and
   the value must match exactly the one set by the client when inserting or
@@ -3598,10 +3612,10 @@ server receives a `TableEntry` message which violates this, it must return an
 `INVALID_ARGUMENT` error.
 
 For more information about idle timeout, in particular regarding
-`IdleTimeoutNotification`, please refer to the [Table idle timeout
-notifications](#sec-table-idle-timeout-notification) section.
+`IdleTimeoutNotification`, please refer to the xref:sec-table-idle-timeout-notification[Table idle timeout notifications] section.
 
-## `ActionProfileMember` & `ActionProfileGroup` { #sec-action-profile-member-and-group }
+[#sec-action-profile-member-and-group]
+== `ActionProfileMember` & `ActionProfileGroup` 
 
 P4Runtime defines an API for programming a PSA ActionProfile extern using
 `ActionProfileMember` messages. A PSA ActionSelector extern can be programmed
@@ -3612,7 +3626,8 @@ entries are directly bound to an action instance. The following P4 snippet
 illustrates an indirect table `t` for L3 routing, implemented with an action
 selector `as`.
 
-~ Begin P4Example
+[source,p4]
+----
 ActionSelector(HashAlgorithm.crc32,
                /*size = */ 32w1024,
                /*output_width = */ 32w10) as;
@@ -3632,7 +3647,7 @@ table t {
   }
   implementation = as;
 }
-~ End P4Example
+----
 
 When programming table `t` in the example above, a P4Runtime client should
 specify the `TableAction` in the `TableEntry` to be a reference to either an
@@ -3656,7 +3671,7 @@ The obtained member id is used to look up the member table in the selector and
 obtain the action specification, which is then used to modify the packet or its
 metadata.
 
-### Action Profile Member Programming
+=== Action Profile Member Programming
 
 Action profile members are entries in the ActionProfile or ActionSelector and
 are referenced by a `uint32` identifier that is bound to an action
@@ -3709,7 +3724,8 @@ ActionSelector objects.  A message with `action_profile_id` equal to the id of
 an existing ActionProfile or ActionSelector object, and a `member_id` equal to
 0, will read all members of that specified object.
 
-### Action Profile Group Programming { #sec-action-profile-group-programming }
+[#sec-action-profile-group-programming]
+=== Action Profile Group Programming 
 
 Action profile groups are entries in an ActionSelector and are referenced by a
 `uint32` identifier that is bound to a set of action profile members already
@@ -3738,27 +3754,27 @@ An `ActionProfileGroup` entity update message has the following fields:
 * `members` is a repeated field defining the set of members that are part of the
   group. For each member in a group, the controller must define the following
   fields:
-    * `member_id` for looking up the member table in the selector.
-    * `weight` specifying the probability of the member's selection at
+    ** `member_id` for looking up the member table in the selector.
+    ** `weight` specifying the probability of the member's selection at
       runtime. 0 is not a valid `weight` value and the server must return
       `INVALID_ARGUMENT` if the client attempts to use it.
-    * `watch_port` is the controller-defined port that the member's
+    ** `watch_port` is the controller-defined port that the member's
       liveness depends on. At runtime, the member must be excluded from
       selection if the watch port is down.  See Section
-      [#action-selector-constraints] for notes on the behavior if all members in
+      <<#action-selector-constraints>> for notes on the behavior if all members in
       a group are excluded for this reason. If `watch_port` is empty, then the
       member is always included in the selection, regardless of the status of
       any port of the device.  The value must be empty or the SDN port of an
       existing port on the device, otherwise the server must return
       `INVALID_ARGUMENT`. If the target does not support using the SDN port as a
-      watch port (&eg; on some targets LAGs cannot be used for this purpose),
+      watch port (e.g. on some targets LAGs cannot be used for this purpose),
       the server must return `UNIMPLEMENTED`.
 
 * `max_size` is the maximum sum of all members or member weights (as per the
   `selector_size_semantics`) for the group. This field is defined when the group
   is inserted, and must not be changed in a `MODIFY` update, otherwise an
   `INVALID_ARGUMENT` error is returned. See the subsection below for the
-  [rules on setting `max_size`](#sec-max-size-rules).
+  xref:sec-max-size-rules[rules on setting `max_size`].
 
 An action profile group may be inserted, modified or deleted as per the
 following semantics.
@@ -3783,7 +3799,7 @@ following semantics.
   field will be ignored.
 
 When setting the group membership with `INSERT` or `MODIFY`, the `members`
-repeated field must not include duplicates, &ie; members with the same
+repeated field must not include duplicates, i.e. members with the same
 `member_id`. The `weight` field is used instead to logically "repeat" the member
 inside the group.
 
@@ -3798,7 +3814,8 @@ message with `action_profile_id` equal to the id of an existing ActionSelector
 object, and a `group_id` equal to 0, will read all groups of that one specified
 object.
 
-#### Rules on Setting `max_size` { #sec-max-size-rules}
+[#sec-max-size-rules]
+==== Rules on Setting `max_size`
 
 The valid values for `max_size` depend on the static `max_group_size` included
 in the P4Info message:
@@ -3810,7 +3827,7 @@ in the P4Info message:
   would have rejected the Forwarding Pipeline Config. If `max_size` is greater
   than `max_group_size`, the server must return `INVALID_ARGUMENT`.
 
-* Otherwise (&ie; if `max_group_size` is 0), the P4Runtime client can set
+* Otherwise (i.e. if `max_group_size` is 0), the P4Runtime client can set
   `max_size` to any value greater than or equal to 0.
 
   * A `max_size` of 0 indicates that the client is not able to specify a maximum
@@ -3823,7 +3840,8 @@ in the P4Info message:
     target, the server must return a `RESOURCE_EXHAUSTED` error at
     group-creation time.
 
-### One Shot Action Selector Programming { #sec-oneshot }
+[#sec-oneshot]
+==== One Shot Action Selector Programming 
 
 P4Runtime supports syntactic sugar to program a table, which is implemented with
 an action selector, in one shot. One shot means that a table entry, an action
@@ -3854,7 +3872,7 @@ is `sum_of_members`, or else the server must return `INVALID_ARGUMENT`. Each
 
 * `watch_port` is the controller-defined port that the action's liveness depends
   on. At runtime, the action must be excluded from selection if the watch port
-  is down. See Section [#sec-action-profile-group-programming] for more details
+  is down. See Section <<#sec-action-profile-group-programming>> for more details
   on the `watch_port` field, which also apply for one shot action selector
   programming.
 
@@ -3868,11 +3886,11 @@ To preserve read-write symmetry, an implementation must answer `ReadRequest`s
 with the original one shot messages. It may not return a desugared version of
 the one shot message.
 
-For example, consider the action selector table defined
-[here](#sec-action-profile-member-and-group). This table could be programmed
+For example, consider the action selector table defined xref:sec-action-profile-member-and-group[role]. This table could be programmed
 with the following one shot update:
 
-~ Begin Prototext
+[source,proto]
+----
 table_entry {
   table_id: 0x0212ab34
   match { /* lpm match */ }
@@ -3896,12 +3914,13 @@ table_entry {
     }
   }
 }
-~ End Prototext
+----
 
 Which would be equivalent to the following updates, where `GROUP_ID`,
 `MEMBER_ID_1`, `MEMBER_ID_2`, and `MEMBER_ID_3` are unused ids:
 
-~ Begin Prototext
+[source,p4]
+----
 action_profile_member {
   action_profile_id: 0x11ab12cd
   member_id: MEMBER_ID_1
@@ -3941,11 +3960,10 @@ table_entry {
   match { /* lpm match */ }
   action { action_profile_group_id: GROUP_ID }
 }
-~ End Prototext
+----
 
 Note that when using the above method (members and groups), the client also
-needs to use multiple messages to ensure [correct ordering between the dependent
-updates](#sec-batching-and-ordering-of-updates). Members need to be inserted
+needs to use multiple messages to ensure xref:sec-batching-and-ordering-of-updates[correct ordering between the dependent updates]. Members need to be inserted
 first, then the group needs to be created, and finally the match entry can be
 inserted. Therefore, 3 distinct `WriteRequest` batches are required.
 
@@ -3955,7 +3973,7 @@ the P4Runtime client is encouraged not to do so, as the same can be achieved by
 using the `weight` field. Note that to preserve read-write symmetry, the server
 must not coalesce multiple `ActionProfileAction` messages with the same `action`
 specification into one. Additionally, each `action` specification would count as
-a separate member for the purposes of &eg; the `sum_of_members` group size
+a separate member for the purposes of e.g. the `sum_of_members` group size
 calculation for Action Selectors.
 
 All the tables associated with an action selector may either be programmed
@@ -3972,14 +3990,15 @@ an action selector implementation. Support for the `ActionProfileMember` and
 `UNIMPLEMENTED` error for every `ActionProfileMember` or `ActionProfileGroup`
 message that it receives.
 
-### Constraints on action selector programming { #action-selector-constraints }
+[#action-selector-constraints]
+==== Constraints on action selector programming 
 
 The PSA specification states that the following features are *optional* in
 action selector implementations [@PSAActionSelector]:
 
-1. Support for non-empty groups where in the same group, different members are
+. Support for non-empty groups where in the same group, different members are
    bound to different actions.
-2. Predictable data plane behavior when a matched table entry points to an empty
+. Predictable data plane behavior when a matched table entry points to an empty
    group.
 
 For 1., if a client tries to `INSERT` or `MODIFY` a group with members bound to
@@ -4012,7 +4031,7 @@ style of programming.
 
 The PSA specification includes a discussion on how to implement
 `psa_empty_group_action` in software in the P4Runtime server
-[@PSAEmptyGroupActionAppendix].
+cite:[PSAEmptyGroupActionAppendix].
 
 If a P4Runtime implementation does support `psa_empty_group_action`, that action
 should be executed when an action selector group is selected that uses the watch
@@ -4024,7 +4043,7 @@ its behavior when a group effectively becomes empty because the watch ports of
 all members of a group are down.
 
 
-## `CounterEntry` & `DirectCounterEntry`
+=== `CounterEntry` & `DirectCounterEntry`
 
 PSA defines Counters as a mechanism for keeping statistics of bytes and packets.
 Statistics may be updated as a result of an action associated with a table
@@ -4035,34 +4054,36 @@ P4Runtime message can be used for all three types of PSA counters --- `PACKETS`,
 * `byte_count` is an `int64`, corresponding to the number of octets.
 * `packet_count` is an `int64`, corresponding to the number of packets.
 
-~ Begin Proto
+[source,proto]
+----
 message CounterData {
   int64 byte_count = 1;
   int64 packet_count = 2;
 }
-~ End Proto
+----
 
 P4Runtime does not distinguish between the different PSA counter types, and
 allows for simultaneous updates of `byte_count` and `packet_count` fields, which
 is equivalent to specifying the counter type `PACKETS_AND_BYTES`. Counters may
 be defined as direct or indirect (indexed) instances.
 
-### `DirectCounterEntry`
+==== `DirectCounterEntry`
 
 A direct counter is a direct resource associated with a `TableEntry` (see
-[Direct Resources](#sec-direct-resources)). The `counter_data` field of the
+xref:sec-direct-resources[Direct Resources]). The `counter_data` field of the
 `TableEntry` message can be used to initialize the counter value at the same
 time as the table entry is inserted. Once the table entry has been created, the
 P4Runtime client may modify the associated direct counter entry using the
 `DirectCounterEntry` message. Once the table entry is deleted the associated
 direct counter entry can no longer be accessed.
 
-~ Begin Proto
+[source,proto]
+----
 message DirectCounterEntry {
   TableEntry table_entry = 1;
   CounterData data = 2;
 }
-~ End Proto
+----
 
 A `WriteRequest` may only include an `Update` message of type `MODIFY` with a
 `DirectCounterEntry`, whose fields are specified by the client as follows:
@@ -4084,14 +4105,14 @@ A client may use `ReadRequest` in two ways to read the contents of a
 
 * As a direct resource associated with a table entry, request the server to
 return the counter value in the `counter_data` field of the `TableEntry` message
-(see [Direct resources](#sec-direct-resources)).
+(see xref:sec-direct-resources[Direct Resources]).
 
 * Explicitly request the counter value by including the `DirectCounterEntry` in
 the `ReadRequest`. The `table_entry.match` field must match the `TableEntry`
 whose counter is being read. If no such entry is found, the server returns the
 error code `NOT_FOUND`.
 
-### `CounterEntry`
+==== `CounterEntry`
 
 An indirect or indexed counter is not associated with a specific `TableEntry`
 and may be updated independently of any action. It may be read or written using
@@ -4105,13 +4126,14 @@ the P4Runtime `CounterEntry` message whose fields are defined as follows:
 * `data` is a Protobuf message of type `CounterData`, which represents the
   counter value.
 
-~ Begin Proto
+[source,p4]
+----
 message CounterEntry {
   uint32 counter_id = 1;
   Index index = 2;
   CounterData data = 3;
 }
-~ End Proto
+----
 
 The `CounterEntry` can only be used in a `WriteRequest` with the `MODIFY` update
 type. The P4Runtime server must return an `INVALID_ARGUMENT` error code for
@@ -4140,16 +4162,16 @@ entity for each of the instances, specifying the `counter_id` and
   values for all indirect counters in the array identified by the unique id
   `counter_id`.
 
-## `MeterEntry` & `DirectMeterEntry`
+=== `MeterEntry` & `DirectMeterEntry`
 
 Meters are an advanced mechanism for keeping statistics, involving stateful
 "marking" and usually "throttling" of packets based on configured rates of
 traffic. The PSA metering function is based on the *Two Rate Three Color Marker*
-(trTCM) defined in RFC 2698 [@RFC2698]. P4Runtime clients may additionally
-restrict meter usage on a table to RFC 2697's [@RFC2697] *Single Rate Three
+(trTCM) defined in RFC 2698 cite:[RFC2698]. P4Runtime clients may additionally
+restrict meter usage on a table to RFC 2697's cite:[RFC2697] *Single Rate Three
 Color Marker* (srTCM) or a simplified version of it that we call *Single Rate
 Two Color Marker*. The type of a table's meter is set by the `MeterSpec.Type` as
-described in the [Meter & DirectMeter section](#sec-meter-directmeter).
+described in the xref:sec-meter-directmeter[Meter & DirectMeter section].
 
 The trTCM meters an arbitrary packet stream using two configured rates ---
 the Peak Information Rate (PIR) and Committed Information Rate (CIR), and their
@@ -4178,7 +4200,8 @@ primary purpose of the color counters is for debugging purposes.
 A meter may be configured as a direct or indirect instance, similar to a
 counter. The `MeterConfig` P4Runtime message represents meter configuration.
 
-~ Begin Proto
+[source,proto]
+----
 message MeterConfig {
   int64 cir = 1;  // Committed Information Rate
   int64 cburst = 2;  // Committed Burst Size
@@ -4186,7 +4209,7 @@ message MeterConfig {
   int64 pburst = 4;  // Peak Burst Size
   int64 eburst = 5; // Excess burst size (only used for srTCM)
 }
-~ End Proto
+----
 
 A MeterConfig for a trTCM typed meter must only be accepted if `eburst` is
 unset. Otherwise, the server should return an `INVALID_ARGUMENT` error.
@@ -4206,23 +4229,23 @@ packets identically in all three cases. Thus, changing the meter type from
 *Single Rate Two Color Marker* to *Single Rate Three Color Marker* or
 *Two Rate Three Color Marker* is a non-breaking change.
 
-### `DirectMeterEntry`
+==== `DirectMeterEntry`
 
-A direct meter is a direct resource associated with a `TableEntry` (see [Direct
-resources](#sec-direct-resources)). The `meter_config` field of the `TableEntry`
+A direct meter is a direct resource associated with a `TableEntry` (see xref:sec-direct-resources[Direct Resources]). The `meter_config` field of the `TableEntry`
 message can be used to initialize the meter configuration at the same time as
 the table entry is inserted. Once the table entry has been created, the
 P4Runtime client may modify the associated direct meter entry using the
 `DirectMeterEntry` message. Once the table entry is deleted the associated
 direct meter entry can no longer be accessed.
 
-~ Begin Proto
+[source,proto]
+----
 message DirectMeterEntry {
   TableEntry table_entry = 1;
   MeterConfig config = 2;
   MeterCounterData counter_data = 3;
 }
-~ End Proto
+----
 
 A `WriteRequest` may only include an `Update` message of type `MODIFY` with a
 `DirectMeterEntry`, whose fields are specified by the client as follows:
@@ -4251,7 +4274,7 @@ A client may use `ReadRequest` in two ways to read a `DirectMeter` config.
 
 * As a direct resource associated with a table entry, request the server to
   return the meter config in the `meter_config` field of the `TableEntry`
-  message (see [Direct resources](#sec-direct-resources)).
+  message (see xref:sec-direct-resources[Direct Resources]).
 
 * Explicitly request the meter configuration by including the `DirectMeterEntry`
   in the `ReadRequest`. The `table_entry.match` field must match the
@@ -4260,7 +4283,7 @@ A client may use `ReadRequest` in two ways to read a `DirectMeter` config.
   per color counter data for the meter entry, if supported and specified in
   the request message.
 
-### `MeterEntry`
+==== `MeterEntry`
 
 An indirect or indexed meter is not associated with a specific `TableEntry` and
 may be executed independently of any action. Its configuration may be read or
@@ -4279,14 +4302,15 @@ follows:
   represents the per color counter values associated with the corresponding
   meter.
 
-~ Begin Proto
+[source,proto]
+----
 message MeterEntry {
   uint32 meter_id = 1;
   Index index = 2;
   MeterConfig config = 3;
   MeterCounterData counter_data = 4;
 }
-~ End Proto
+----
 
 The `MeterEntry` can only be used in a `WriteRequest` with the `MODIFY` update
 type.  The P4Runtime server must return an `INVALID_ARGUMENT` error code for
@@ -4317,7 +4341,7 @@ supported as follows:
   configuration for all indirect meters in the array identified by the unique id
   `meter_id`.
 
-### `MeterCounterData`
+==== `MeterCounterData`
 
 The `MeterCounterData` P4Runtime message represents the per color counters
 associated with a meter entry. Whenever a meter is executed and returns
@@ -4328,16 +4352,16 @@ As seen above, these counters can be associated with a `DirectMeterEntry` or
 `UNIMPLEMENTED` if a `MeterCounterData` field was set in a read or write
 request.
 
-~ Begin Proto
+[source,p4]
+----
 message MeterCounterData {
   CounterData green = 1;
   CounterData yellow = 2;
   CounterData red = 3;
 }
-~ End Proto
+----
 
-
-## `PacketReplicationEngineEntry`
+=== `PacketReplicationEngineEntry`
 
 The PSA Packet Replication Engine (PRE) is an extern that is implicitly
 instantiated in all PSA programs. The PRE is responsible for implementing
@@ -4345,7 +4369,7 @@ multicasting and cloning functionality in the data plane. P4Runtime defines an
 API to program the PRE with multicast groups and clone sessions to allow
 replication of data plane packets.
 
-### `MulticastGroupEntry`
+==== `MulticastGroupEntry`
 
 Multicasting is achieved in PSA programs by setting the `multicast_group`
 ingress output metadata to a non-zero identifier. The number of replicas and
@@ -4355,7 +4379,8 @@ program illustrates a possible data plane behavior of multicasting ARP packets
 in the ingress. Note that the data plane type of the multicast group metadata is
 10 bits on the PSA device in this example.
 
-~ Begin P4Example
+[source,p4]
+----
 control arp_multicast(inout H hdr, inout M smeta) {
   apply {
     if (hdr.ethernet.isValid() &&
@@ -4364,12 +4389,13 @@ control arp_multicast(inout H hdr, inout M smeta) {
     }
   }
 }
-~ End P4Example
+----
 
 At runtime, the client writes the following update in the target (shown in
 Protobuf text format).
 
-~ Begin Prototext
+[source,proto]
+----
 type: INSERT
 entity {
   packet_replication_engine_entry {
@@ -4382,14 +4408,13 @@ entity {
     }
   }
 }
-~ End Prototext
+----
 
 As a result of the above P4Runtime programming, the target device will create
 four replicas of an ARP packet. These replicas will appear in the egress
 pipeline as independent packets with egress port set to PSA device port numbers
 corresponding to SDN port numbers 5, 12, 18 and 24. For more discussion on the
-translation between SDN ports and PSA device ports, refer to the
-[PSA Metadata Translation](#sec-translation-of-port-numbers) section.
+translation between SDN ports and PSA device ports, refer to the xref:sec-translation-of-port-numbers[PSA Metadata Translation] section.
 
 The egress packets may be distinguished for further processing in the egress
 using the `instance` metadata. Note that a packet may not be both unicast and
@@ -4402,7 +4427,7 @@ semantics.
 
 * `INSERT`: Add a new multicast group entry bound to a set of egress ports and
   replica IDs. The `multicast_group_id` field is a `uint32` and must be greater
-  than 0 (see explanation [below](#sec-valid-values-for-mg-id)), or the
+  than 0 (see explanation xref:sec-valid-values-for-mg-id[below]), or the
   P4Runtime server must return an `INVALID_ARGUMENT` error. The replica
   `instance` ID is also a `uint32`, and its value may not exceed the maximum
   allowed by the target for the `EgressInstance_t` type (0 is allowed), or the
@@ -4427,7 +4452,8 @@ other fields in `MulticastGroupEntry` are ignored. To perform a *wildcard*
 `Read` on all configured multicast group entries, the `multicast_group_id` field
 must be set to 0, its default value.
 
-#### Valid Values for `multicast_group_id` { #sec-valid-values-for-mg-id}
+[#sec-valid-values-for-mg-id]
+==== Valid Values for `multicast_group_id` 
 
 The PSA specification states that the valid *data plane* values for multicast
 group ids (`MulticastGroup_t`) range from 1 (0 is a special value that indicates
@@ -4442,7 +4468,7 @@ multicast group ids. In other words, it is not possible to map (using
 translation) a zero SDN multicast group id value to a non-zero data plane
 multicast group id value.
 
-### `CloneSessionEntry`
+==== `CloneSessionEntry`
 
 PSA supports cloning of packets in both the ingress and egress pipeline. Ingress
 cloning creates a mirror of the packet as seen in the beginning of the ingress
@@ -4461,7 +4487,8 @@ type of the clone session metadata is 10 bits on the PSA device in this example.
 We assume that the `clone_low_ttl` control block is applied in the ingress
 pipeline to create an ingress-to-egress clone.
 
-~ Begin P4Example
+[source,p4]
+----
 control clone_low_ttl(inout H hdr, inout M smeta) {
   apply {
     if (hdr.ipv4.isValid() &&
@@ -4471,13 +4498,14 @@ control clone_low_ttl(inout H hdr, inout M smeta) {
     }
   }
 }
-~ End P4Example
+----
 
 
 At runtime, the client writes the following update in the target (shown in
 Protobuf text format).
 
-~ Begin Prototext
+[source,proto]
+----
 type: INSERT
 entity {
   packet_replication_engine_entry {
@@ -4489,20 +4517,20 @@ entity {
     }
   }
 }
-~ End Prototext
+----
 
 As a result of the above P4Runtime programming, the target device will create
 one replica of a low TTL packet from the ingress to the egress. Note that the
 clone session ID of the programmed PRE entry is identical to the value used in
 the data plane in this example (no numerical translation, which is the default
-for values of type `CloneSessionId_t` [@PSATranslation]). The clone will be
+for values of type `CloneSessionId_t` cite:[PSATranslation]). The clone will be
 treated for scheduling in the PRE with a class of service value of 2. If the
 packet is larger than 4096 bytes, it will be truncated to carry at most 4096
 bytes.
 
 The cloned replica will appear in the egress pipeline as an independent packet
 with egress port set to CPU (corresponding to SDN port `0xfffffffd`; see
-[Translation of Port Numbers](#sec-translation-of-port-numbers)). Note that the
+xref:sec-translation-of-port-numbers[Translation of Port Numbers]). Note that the
 egress port (`port` field) must be an SDN port and must refer to a singleton
 port.
 
@@ -4514,7 +4542,7 @@ semantics:
 
 * `INSERT`: Add a new clone session entry bound to a set of egress ports and
   replica IDs. The `session_id` is a `uint32` and must be greater than 0 (see
-  explanation [below](#sec-valid-values-for-session-id)), or the P4Runtime
+  explanation xref:sec-valid-values-for-session-id[below], or the P4Runtime
   server must return an `INVALID_ARGUMENT` error. The replica `instance` ID is
   also a `uint32`, and its value may not exceed the maximum allowed by the
   target for the `EgressInstance_t` type (0 is allowed), or the server must also
@@ -4523,13 +4551,12 @@ semantics:
   service for each clone packet instance will be set to the value programmed in
   the clone session entry (`class_of_service` field). This value must be a valid
   value for the PSA `ClassOfService_t` type, which supports runtime translation
-  by default [@PSATranslation], or the server must return
-  `INVALID_ARGUMENT`. See [PSA Metadata
-  Translation](#sec-translation-of-port-numbers) for more information. The
-  `packet_length_bytes` field must be set to a non-zero value if the clone
-  packet should be truncated to the given value (in bytes). If the
-  `packet_length_bytes` field is 0 (default), no truncation on the clone will be
-  performed.
+  by default cite:[PSATranslation], or the server must return
+  `INVALID_ARGUMENT`. See xref:sec-translation-of-port-numbers[PSA Metadata
+  Translation] for more information. The `packet_length_bytes` field must be 
+  set to a non-zero value if the clone packet should be truncated to the given 
+  value (in bytes). If the`packet_length_bytes` field is 0 (default), 
+  no truncation on the clone will be performed.
 * `MODIFY`: Modify the attributes of a given clone session entry, indexed by the
   given `clone_session_id`. Same restrictions as `INSERT` apply here.
 * `DELETE`: Delete the clone session indexed by the given
@@ -4543,24 +4570,24 @@ configured clone session entries, the `session_id` field must be set to 0, its
 default value. The `session_id` field can never be equal to 0 in a `Write`
 RPC. If it does, the server must return an `INVALID_ARGUMENT` error.
 
-#### Valid Values for `session_id` { #sec-valid-values-for-session-id}
+[#sec-valid-values-for-session-id]
+==== Valid Values for `session_id` 
 
 The PSA specification states that the valid *data plane* values for clone
 session ids (`CloneSessionId_t`) range from 0 to the maximum value supported by
-the target [@PSATranslation]. Note that unlike for [multicast group
-ids](#sec-valid-values-for-mg-id), 0 is a valid *data plane* value for clone
+the target cite:[PSATranslation]. Note that unlike for xref:sec-valid-values-for-mg-id[multicast group ids], 0 is a valid *data plane* value for clone
 session ids. However, just like for multicast group ids, P4Runtime reserves 0 as
 a special *wildcard* value which is used to read all the clone sessions
 configured in the target. This means that 0 can never be used as a `session_id`
 value when inserting a clone session, whether or not numeric translation is
 enabled for clone session ids. If translation is *not* enabled, we effectively
 "lose" one clone session, assuming the target supports 0 as mandated by the PSA
-specification. If this is an issue (&eg; because the target supports a very
+specification. If this is an issue (e.g. because the target supports a very
 limited number of clone sessions), one can enable translation on
 `CloneSessionId_t` and map any non-zero SDN session id to the data plane clone
 session with id 0, then insert a clone session with the chosen SDN session id.
 
-## `ValueSetEntry`
+=== `ValueSetEntry`
 
 Parser Value Set is a construct in P4 that is used to support programmability of
 parser state transitions. A transition select statement in P4 can use a parser
@@ -4568,7 +4595,8 @@ Value Set to define a runtime programmable state transition as shown in the
 example below. A runtime programmable set of TRILL Ethertypes is used to
 transition the parser state machine to the `parse_trill_types` state.
 
-~ Begin P4Example
+[source,p4]
+----
 state parse_l2 {
   @id(1) value_set<ETH_TYPE_BITWIDTH>(MAX_TRILL_TYPES) trill_types;
   extract(hdr.ethernet);
@@ -4579,11 +4607,12 @@ state parse_l2 {
     _:             reject;
   }
 }
-~ End P4Example
+----
 
 The corresponding entry in the P4Info for this Value Set is:
 
-~ Begin Prototext
+[source,proto]
+----
 value_sets {
   preamble {
     id: 0x03000001
@@ -4596,12 +4625,13 @@ value_sets {
   }
   size: <MAX_TRILL_TYPES>
 }
-~ End Prototext
+----
 
 At runtime, the client writes the following update in the target (shown in
 Protobuf text format).
 
-~ Begin Prototext
+[source,proto]
+----
 type: MODIFY
 entity {
   value_set_entry {
@@ -4618,7 +4648,7 @@ entity {
     }
   }
 }
-~ End Prototext
+----
 
 As a result of the above P4Runtime programming, all packets with EtherType
 values of 0x22f3 and 0x893b will be parsed as per the state machine starting at
@@ -4638,7 +4668,7 @@ A `ValueSetEntry` entity update message has the following fields:
   it matches all its `FieldMatch` messages. This is similar to how a packet
   matches a table entry if and only if it matches all the components of the
   match key for this entry. `FieldMatch` messages in a `ValueSetEntry` follow
-  the [same rules](#sec-match-format) as in a `TableEntry`.
+  the xref:sec-match-format[same rules] as in a `TableEntry`.
 
 A `ValueSetEntry` may only be modified. If the update type is `INSERT` or
 `DELETE`, the server must return an `INVALID_ARGUMENT` error. If the update type
@@ -4646,19 +4676,19 @@ is `MODIFY`, the server writes the members given in the repeated field to the
 Value Set entry indexed by the given `value_set_id`. The maximum number of
 matches must not exceed the maximum size given by the `size` field in P4Info of
 the Value Set, otherwise the server must return a `RESOURCE_EXHAUSTED` error. To
-empty a Value Set (&ie; restore it to its initial state), the P4Runtime client
+empty a Value Set (i.e. restore it to its initial state), the P4Runtime client
 can perform a `MODIFY` update with an empty `members` repeated field.
 
-To facilitate [read-write symmetry](#sec-read-write-symmetry), the server must
+To facilitate xref:sec-read-write-symmetry[read-write symmetry], the server must
 return an `ALREADY_EXISTS` error in case of duplicate members. Unlike for match
 tables, a priority value is not required for ternary, range and optional
 matches: overlapping entries do not need to be ordered and the parse state
 transition is determined by whether or not the packet matches at least one entry
 in the set.
 
-See Appendix [#sec-value-set-example] for a more complex Value Set example.
+See Appendix <<#sec-value-set-example>> for a more complex Value Set example.
 
-## `RegisterEntry`
+=== `RegisterEntry`
 
 The PSA Register extern is a stateful memory array that can be read and written
 during packet forwarding. The `RegisterEntry` P4Runtime entity is used by the
@@ -4685,7 +4715,8 @@ control plane operations.
   Register entry in the P4Info, or the server must return an `INVALID_ARGUMENT`
   error.
 
-## `DigestEntry` { #sec-digestentry }
+[#sec-digestentry]
+=== `DigestEntry` 
 
 A digest is one mechanism to send a message from the data plane to the
 control plane. It is traditionally used for MAC address learning: when a packet
@@ -4717,12 +4748,12 @@ if they are not duplicate.
   digest messages are exchanged between server and client for a given
   `digest_id`; these parameters are:
 
-    * `max_timeout_ns`: the maximum server buffering delay in nanoseconds for an
+    ** `max_timeout_ns`: the maximum server buffering delay in nanoseconds for an
       outstanding digest message.
-    * `max_list_size`: the maximum digest list size --- in number of digest
+    ** `max_list_size`: the maximum digest list size --- in number of digest
       messages --- sent by the server to the client as a single `DigestList`
       Protobuf message.
-    * `ack_timeout_ns`: the timeout in nanoseconds that a server must wait for a
+    ** `ack_timeout_ns`: the timeout in nanoseconds that a server must wait for a
       digest list acknowledgement from the client before new digest messages can
       be generated for the same learned data.
 
@@ -4755,7 +4786,7 @@ digest list and acted on it. The server must keep a "cache" containing the set
 of all digest messages that have been sent, but not acknowledged yet by the
 primary client, up-to `ack_timeout_ns` in the past. The server must delete all
 cache entries for a given digest list when they are at least `ack_timeout_ns`
-old or when a matching `DigestListAck` message (&ie; with the same `digest_id`
+old or when a matching `DigestListAck` message (i.e. with the same `digest_id`
 and `list_id` fields as the `DigestList` message) is received.
 
 The acknowledgement mechanism described above is not used to implement some sort
@@ -4779,7 +4810,8 @@ status change.
 Here is some pseudo-code implementing the handling of digest messages in the
 P4Runtime server:
 
-~ Begin CPP
+[source,p4]
+----
 DigestStream stream;
 DigestCache cache;
 DigestBuffer buffers;
@@ -4823,78 +4855,82 @@ while (true) {
   }
   sleep(X);
 }
-~ End CPP
+----
 
-## `ExternEntry` { #sec-extern-entry}
+[#sec-extern-entry]
+=== `ExternEntry` 
 
 This is used to support a P4 extern entity that is not part of PSA. It is
 defined as:
 
-~ Begin Proto
+[source,proto]
+----
 message ExternEntry {
   uint32 extern_type_id = 1;
   uint32 extern_id = 2;
   google.protobuf.Any entry = 3;
 }
-~ End Proto
+----
 
 Each `ExternEntry` entity maps to an `Extern` message in the
-[P4Info](#sec-p4info-extern) and an `ExternInstance` message within that
+xref:sec-p4info-extern[P4Info] and an `ExternInstance` message within that
 message. The `extern_type_id` field must be equal to the one in
 `ExternEntry`. The `extern_id` field must be equal to the ID included in the
 `preamble` of the corresponding `ExternInstance` message.
 
-`entry` itself is embedded as an `Any` Protobuf message [@ProtoAny] to keep the
+`entry` itself is embedded as an `Any` Protobuf message cite:[ProtoAny] to keep the
 protocol extensible. It includes the extern-specific parameters required by the
 P4Runtime server to perform the read or write operation. The underlying Protobuf
 message should be defined in a separate architecture-specific Protobuf file. See
-section on [Extending P4Runtime for non-PSA
-Architectures](#sec-extending-p4runtime) for more information.
+section on xref:sec-extending-p4runtime[Extending P4Runtime for non-PSA
+Architectures] for more information.
 
-# Error Reporting Messages { #sec-error-reporting-messages}
+[#sec-error-reporting-messages]
+=== Error Reporting Messages 
 
 P4Runtime is based on gRPC and all RPCs return a status to indicate success or
 failure. gRPC supports multiple language bindings; we use C++ binding below to
 explain how error reporting works in the failure case.
 
-gRPC uses `grpc::Status` [@gRPCStatus] to represent the status returned by an
+gRPC uses `grpc::Status` cite:[gRPCStatus] to represent the status returned by an
 RPC. It has 3 attributes:
 
-~ Begin CPP
+[source,cpp]
+----
 StatusCode code_;
 grpc::string error_message_;
 grpc::string binary_error_details_;
-~ End CPP
+----
 
-The `code_` represents a canonical error [@gRPCStatusCodes] and describes the
+The `code_` represents a canonical error cite:[gRPCStatusCodes] and describes the
 overall RPC status. The `error_message_` is a developer-facing error message,
 which should be in English. The `binary_error_details_` carries a serialized
-`google.rpc.Status` message [@ProtoStatus] message, which has 3 fields:
+`google.rpc.Status` message cite:[ProtoStatus] message, which has 3 fields:
 
-~ Begin Proto
+[source,proto]
+----
 int32 code = 1;  // see code.proto
 string message = 2;
 repeated google.protobuf.Any details = 3;
-~ End Proto
+----
 
 The code and message fields must be the same as `code_` and `error_message_`
 fields from `grpc::Status` above. The `details` field is a list that consists of
 `p4.Error` messages that carry error details for individual elements inside
-batch-request RPCs (&eg; `Write` and `Read`). `p4.Error` includes a canonical
+batch-request RPCs (e.g. `Write` and `Read`). `p4.Error` includes a canonical
 error code but also enables different target vendors to additionally express
 their own error codes in their chosen error-space. This specification document
 tries to cover all possible generic error cases and to provide the appropriate
-value for the canonical error code based on best practices [@gRPCStatusCodes].
+value for the canonical error code based on best practices cite:[gRPCStatusCodes].
 
-Figure [#fig-error-report] illustrates how these messages fit together.
+Figure ,,<<#fig-p4prg>>.. illustrates how these messages fit together.
 
-~ Figure { #fig-error-report; caption: "P4Runtime Error Report Message Format" }
-![error-report]
-~
-[error-report]: build/error-report.[svg,png] { width: 70%; page-align: here }
+.P4Runtime Error Report Message Format.
+[#fig-p4prg]
+image::error-report.png[]
 
 gRPC provides utility functions `ExtractErrorDetails()` and `SetErrorDetails()`
-[@gRPCErrorDetails] to easily convert between `grpc::Status` and
+cite:[gRPCErrorDetails] to easily convert between `grpc::Status` and
 `google.rpc.Status`.
 
 Please see sections on individual P4Runtime RPCs for details on how
@@ -4903,10 +4939,10 @@ Please see sections on individual P4Runtime RPCs for details on how
 Note that P4Runtime also provides a way for the server to asynchronously report
 errors which occur when processing stream messages from the client. This
 error-reporting mechanism is orthogonal to the one described in this section,
-which applies to unary RPCs. See the section on [Stream Error
-Reporting](#sec-stream-error-reporting) for more information.
+which applies to unary RPCs. See the section on xref:sec-stream-error-reporting[Stream Error
+Reporting] for more information.
 
-# Atomicity of Individual `Write` and `Read` Operations
+=== Atomicity of Individual `Write` and `Read` Operations
 
 Each individual entity in a batch is guaranteed to be read or written atomically
 relative to packet forwarding. For example, for every table data plane `apply`
@@ -4920,16 +4956,17 @@ data plane methods.
 
 The atomicity guarantees provided by P4Runtime for individual `Read` and `Write`
 operations are the same as the guarantees required by PSA and are described in
-details in the PSA specification [@PSAAtomicityOfControlPlaneOps].
+details in the PSA specification cite:[PSAAtomicityOfControlPlaneOps].
 
-The P4~16~ language introduces an `@atomic` annotation [@P4Concurrency], to
+The P4~16~ language introduces an `@atomic` annotation cite:[P4Concurrency], to
 guarantee atomic data plane execution of entire blocks of P4 code. P4Runtime
 implementations are required to honor the `@atomic` annotation for `Write`
-operations, as well as [non-wildcard `Read` operations](#sec-wildcard-reads),
+operations, as well as xref:sec-wildcard-reads[non-wildcard `Read` operations],
 relative to data plane execution. Consider the following P4 example written for
 PSA:
 
-~ Begin P4Example
+[source,p4]
+----
 control C1 {
   typedef bit<10> Index_t;
   typedef bit<32> Value_t;
@@ -4944,7 +4981,7 @@ control C1 {
     }
   }
 }
-~ End P4Example
+----
 
 If a P4Runtime server is processing messages which write to Register `r1` at
 index `1`, these writes must not happen between the data plane `read` and
@@ -4952,7 +4989,8 @@ index `1`, these writes must not happen between the data plane `read` and
 
 Now let's consider the following example:
 
-~ Begin P4Example
+[source,p4]
+----
 control C1 {
   typedef bit<10> Index_t;
   typedef bit<32> Value_t;
@@ -4969,7 +5007,7 @@ control C1 {
     }
   }
 }
-~ End P4Example
+----
 
 If a P4Runtime client issues a *wildcard* `Read` on Register `r1`, there is no
 guarantee that `r1[1] == r1[2]` in the response, as the read for `r1[1]` may
@@ -4988,12 +5026,14 @@ If the `@atomic` annotation cannot be honored with the above guarantees by the
 P4Runtime implementation for a P4-programmable target, we expect the P4 compiler
 to reject the program.
 
-# `Write` RPC { #sec-write-rpc }
+[#sec-write-rpc]
+=== `Write` RPC 
 
 The `Write` RPC updates one or more P4 entities on the target. The request is
 defined as follows:
 
-~ Begin Proto
+[source,proto]
+----
 message WriteRequest {
   uint64 device_id = 1;
   string role = 6;
@@ -5006,29 +5046,29 @@ message WriteRequest {
   }
   Atomicity atomicity = 5;
 }
-~ End Proto
+----
 
 The `device_id` uniquely identifies the target P4 device. The `role` and
 `election_id` define the client role and election-id as described in the
-[Primary-Backup Arbitration and Controller
-Replication](#sec-client-arbitration-and-controller-replication)
-section. The server is expected to perform the following checks (in this order)
+xref:sec-client-arbitration-and-controller-replication[Primary-Backup Arbitration and Controller
+Replication]section. The server is expected to perform the following checks (in this order)
 before processing the `updates` list:
 
-1. If `device_id` does not match any of the devices known to the P4Runtime
+. If `device_id` does not match any of the devices known to the P4Runtime
    server or if `role` does not match any of the roles for the device, the
    server must return a `NOT_FOUND` error.
 
-2. If the client is not the primary for (`device_id`, `role`) according to
+. If the client is not the primary for (`device_id`, `role`) according to
    the `election_id` value, the server must return a `PERMISSION_DENIED` error.
 
-3. If the `Write` is attempted before a `ForwardingPipelineConfig` has been set,
+. If the `Write` is attempted before a `ForwardingPipelineConfig` has been set,
    the server must return a `FAILED_PRECONDITION` error.
 
 The updates field is a list of P4 entity updates to be applied. Each update is
 defined as:
 
-~ Begin Proto
+[source,proto]
+----
 message Update {
   enum Type {
     UNSPECIFIED = 0;
@@ -5039,11 +5079,11 @@ message Update {
   Type type = 1;
   Entity entity = 2;
 }
-~ End Proto
+----
 
 This is modeled as performing an update operation on the given entity against
-its entity container. The entity container is either a *logical* table (&eg;
-`CounterEntry`) or an actual table (&eg; `TableEntry`) in the P4 data
+its entity container. The entity container is either a *logical* table (e.g.
+`CounterEntry`) or an actual table (e.g. `TableEntry`) in the P4 data
 plane. Each entity in the container is uniquely identified by its *key*. Please
 refer to the [P4 Entity Messages](#sec-p4-entity-msgs) section for details on
 what parts of the entity specification make up the *key* for each P4 entity.
@@ -5055,14 +5095,14 @@ An update can be one of the following types:
   If the entity already exists, an `ALREADY_EXISTS` error is returned, and
   the existing entity remains unchanged. If the entity is malformed, an
   `INVALID_ARGUMENT` error is usually returned (unless a more specific error
-  code applies [@gRPCStatusCodes]). If the entity cannot be inserted because the
+  code applies cite:[gRPCStatusCodes]). If the entity cannot be inserted because the
   container is already full, a `RESOURCE_EXHAUSTED` error is returned.
 
 * `MODIFY`: Modifies the P4 entity to its new specified state. This uses
   *assign* or *full-snapshot* semantics, &ie; the entity field contains the
   complete new state of the entity, not a diff from its previous state. If the
   entity is malformed, an `INVALID_ARGUMENT` error is usually returned (unless a
-  more specific error code applies [@gRPCStatusCodes]). If the entity does not
+  more specific error code applies cite:[gRPCStatusCodes]). If the entity does not
   exist, a `NOT_FOUND` error is returned.
 
 * `DELETE`: Deletes the specified P4 entity. If the entity does not exist, a
@@ -5072,7 +5112,8 @@ An update can be one of the following types:
 If an update is not allowed under the given controller role, the server must
 return a `PERMISSION_DENIED` error for this update.
 
-## Batching and Ordering of Updates { #sec-batching-and-ordering-of-updates}
+[#sec-batching-and-ordering-of-updates]
+=== Batching and Ordering of Updates 
 
 P4Runtime supports batching of `Write` operations. The list of updates in a
 `WriteRequest` is referred to as a *batch*. A batch can consist of arbitrary
@@ -5086,21 +5127,21 @@ However, **the processing of requests must be strictly serializable**.  That
 is, given a history $S$ of `WriteRequest`s including the responses to those
 requests, there must exist an order $L$ for all updates in $S$, such that:
 
-1. All updates from the same write request must appear as a contiguous
+. All updates from the same write request must appear as a contiguous
    subsequence in $L$, but the order within that subsequence can be arbitrary.
-2. For two updates $u_1$ and $u_2$, if the write request containing $u_1$
+. For two updates $u_1$ and $u_2$, if the write request containing $u_1$
    completed before the write request of $u_2$ was sent, then $u_1$ must appear
    before $u_2$ in $L$.
-3. Executing all updates in $L$ sequentially must yield the same response for
+. Executing all updates in $L$ sequentially must yield the same response for
    every update as in $S$.
-4. The observable state of the switch after $S$ (&eg;, through the `Read` RPC)
+. The observable state of the switch after $S$ (e.g., through the `Read` RPC)
    is identical to the one obtained by sequentially executing $L$.
 
 The `Write` RPC demarcates the batch boundary, and can be used to ensure
 ordering between dependent updates. When the `Write` RPC returns, it is required
 that all operations in the batch have been committed to the P4 data plane, with
 the exception of any operations that return an error status.  If two updates
-from the client depend on each other (&eg; inserting an `ActionProfileMember`
+from the client depend on each other (e.g. inserting an `ActionProfileMember`
 followed by pointing a `TableEntry` to it) and the updates are not split into
 separate batches, then the behavior may be non-deterministic.  Similarly,
 clients can invoke multiple outstanding `Write` RPCs. If the updates across
@@ -5112,8 +5153,8 @@ wants to enforce that batches are applied in a specific order, each `Write` call
 should be sent sequentially, waiting for the previous call to be acknowledged
 before sending the next one.
 
-
-## Batch Atomicity { #sec-batch-atomicity}
+[#sec-batch-atomicity]
+=== Batch Atomicity 
 
 A P4Runtime server may arbitrarily reorder messages within a batch. The
 atomicity semantics of the batch operations are defined by the `Atomicity`
@@ -5142,7 +5183,7 @@ enum. A P4Runtime server is required to support only the modes marked as
 
   If a P4Runtime server does not support this option at all, an
   `UNIMPLEMENTED` error is returned at all times. If a P4Runtime
-  supports some batches in an rollback way but not others (&eg; it is
+  supports some batches in an rollback way but not others (e.g. it is
   more straightforward to implement batches that contain only `INSERT`
   operations, vs. those that contain `DELETE` operations), an
   `UNIMPLEMENTED` error is returned when the batch cannot be executed
@@ -5172,22 +5213,22 @@ atomicity mode as it sees fit. For example, for a set of entities, a client may
 decide to use `DATAPLANE_ATOMIC` at one time and default behavior
 (`CONTINUE_ON_ERROR`) at other times.
 
-## Error Reporting
+=== Error Reporting
 
 Please see section [Error Reporting Messages](#sec-error-reporting-messages) for
 information on error reporting messages and guidelines. P4Runtime server will
 populate `grpc::Status` as follows:
 
-1. If all batch updates succeeded, set `grpc::Status::code_` to `OK` and do not
+. If all batch updates succeeded, set `grpc::Status::code_` to `OK` and do not
    populate any other field.
 
-2. If an error is encountered before even trying to attempt individual batch
+. If an error is encountered before even trying to attempt individual batch
    updates, set `grpc::Status::code_` that best describes that RPC-wide
    error. For example, use `UNAVAILABLE` if the P4Runtime service is not yet
    ready to handle requests. Set `error_message_` to describe the issue. Do not
    set `error_details` in this case.
 
-3. Otherwise, if one or more updates in the batch (`WriteRequest.updates`)
+. Otherwise, if one or more updates in the batch (`WriteRequest.updates`)
    failed, set `grpc::Status::code_` to `UNKNOWN`. For example, one update in
    the batch may fail with `RESOURCE_EXHAUSTED` and another with
    `INVALID_ARGUMENT`. A `p4.Error` message is used to capture the status of
@@ -5198,7 +5239,8 @@ populate `grpc::Status` as follows:
    updates. If some of the updates were successful, the corresponding
    `p4.Error` should set the code to `OK` and omit other fields.
 
-~ Begin Prototext
+[source,prototext]
+----
 # Example of a grpc::Status returned for a Write RPC with a batch of 3 updates.
 # The first and third updates encountered an error, while the second update
 # succeeded.
@@ -5223,20 +5265,21 @@ binary_error_details {
     code: 600  # ERR_ENTITY_ALREADY_EXISTS
   }
 }
-~ End Prototext
+----
 
-# `Read` RPC
+=== `Read` RPC
 
 The `Read` RPC retrieves one or more P4 entities from the P4Runtime server. The
 request is defined as:
 
-~ Begin Proto
+[source,proto]
+----
 message ReadRequest {
   uint64 device_id = 1;
   string role = 3;
   repeated Entity entities = 2;
 }
-~ End Proto
+----
 
 The `device_id` uniquely identifies the target P4 device. If it does not match
 any of the devices known to the P4Runtime server, the server must return a
@@ -5255,20 +5298,21 @@ require an `election_id`, and they do not require the presence of an open
 The `Read `response consists of a sequence of messages (a gRPC `stream`) with
 each message defined as:
 
-~ Begin Proto
+[source,proto]
+----
 message ReadResponse {
   repeated Entity entities = 1;
 }
-~ End Proto
+----
 
 The `entities` repeated field is a list of P4 entities retrieved. The client
 reads from the returned stream until it is closed by the server when there are
 no more messages. In case of error, the stream is closed prematurely by the
 server and the client obtains the error status (in C++ the error status is
 obtained by calling the `Finish()` method on the stream object
-[@gRPCStreamC]).
+cite:[gRPCStreamC]).
 
-## Nomenclature
+=== Nomenclature
 
 * request
   : An element of the `p4.ReadRequest.entities` repeated field.
@@ -5277,14 +5321,15 @@ obtained by calling the `Finish()` method on the stream object
 
 Each *request* acts as a query filter for that entity type. If a *request* fully
 specifies the entity key, the `Read` operation should retrieve a single P4
-entity.  Please refer to the [P4 Entity Messages](#sec-p4-entity-msgs) section
+entity.  Please refer to the xref:sec-p4-entity-msgs[P4 Entity Messages] section
 for details on what parts of the entity specification make up the entity *key*.
 
-## Wildcard Reads { #sec-wildcard-reads}
+[#sec-wildcard-reads]
+=== Wildcard Reads 
 
 P4Runtime allows wildcard read of P4 entities. A *request* may omit or use
 default values for parts of the entity key to achieve wildcard behavior. Please
-refer to the [P4 Entity Messages](#sec-p4-entity-msgs) section for details on
+refer to the xref:sec-p4-entity-msgs[P4 Entity Messages] section for details on
 what parts of the entity can be wildcarded in a given *request*.
 
 For example, in a *request* of type `CounterEntry`:
@@ -5298,7 +5343,8 @@ For example, in a *request* of type `CounterEntry`:
 To read the entire forwarding state for a given device, the P4Runtime client can
 generate the following `ReadRequest`:
 
-~ Begin Prototext
+[source,proto]
+----
 device_id: <ID>
 entities {
   extern_entry { }  # read all extern instances for all supported extern types
@@ -5307,16 +5353,16 @@ entities {
   action_profile_group { }  # read all groups for all action profiles
   ...
 }
-~ End Prototext
+----
 
 The `entity` oneof field in the `Entity` message must always be set, or the
 server must return an `INVALID_ARGUMENT` error. In other words, P4Runtime does
 not support performing a wildcard read on the entire forwarding state by
 including an empty `Entity` message in the `ReadRequest`. The main reason for
 this decision is to prevent backwards-compatibility issues if new entity types
-are added to the `entity` oneof [@ProtoOneOfBackwardsCompatibility].
+are added to the `entity` oneof cite:[ProtoOneOfBackwardsCompatibility].
 
-## Batch Processing
+=== Batch Processing
 
 A P4Runtime server may arbitrarily reorder requests within a batch to maximize
 performance. There is no requirement that a particular entity type *request*
@@ -5324,27 +5370,27 @@ appears only once in the batch.
 
 A P4Runtime server will process the batch as follows:
 
-1. Lock state (preventing new writes) and validate each *request* in the batch:
+. Lock state (preventing new writes) and validate each *request* in the batch:
 
-    1. If it is a valid *request*, perform the read;
+    .. If it is a valid *request*, perform the read;
 
-        1. If the read was successful, return the entities read in
+        ... If the read was successful, return the entities read in
            `ReadResponse` stream.
-        2. If the read failed (exception / critical-error), prepare a `p4.Error`
+        ... If the read failed (exception / critical-error), prepare a `p4.Error`
            with code set to `INTERNAL`.
 
-    2. If the *request* is invalid (invalid-argument, not-supported, etc.),
+    .. If the *request* is invalid (invalid-argument, not-supported, etc.),
        prepare a `p4.Error` with relevant canonical code to capture the error.
 
-2. Unlock the state (allowing new writes);
+. Unlock the state (allowing new writes);
 
-3. Close the `ReadResponse` stream and return a `grpc::Status` as follows:
+. Close the `ReadResponse` stream and return a `grpc::Status` as follows:
 
-    1. If no errors were encountered, set code to `OK` and do not populate any
+    .. If no errors were encountered, set code to `OK` and do not populate any
        other field.
 
-    2. Otherwise, the overall code should be set to `UNKNOWN`. See section
-       [Error Reporting Messages](#sec-error-reporting-messages) for information
+    .. Otherwise, the overall code should be set to `UNKNOWN`. See section
+       xref:sec-error-reporting-messages[Error Reporting Messages]for information
        on error reporting messages and guidelines. Assemble a list of `p4.Error`
        messages (from step 1 above) such that each element reflects the status
        of the request in the batch at the same location (1:1
@@ -5352,14 +5398,14 @@ A P4Runtime server will process the batch as follows:
        `google.rpc.Status.details` field. This behavior also matches `Write`
        RPC.
 
-### Example
+==== Example
 
 If a client asked to read `{a,b,c,d}` and `b` and `d` *requests* didn't
 validate, the server will return entities corresponding to `a` and `c`, followed
 by a status `{p4.Error(OK), p4.Error(xxx), p4.Error(yyy), p4.Error(OK)}` in the
 `details` field.
 
-The P4Runtime server is not required to perform any optimization (&eg; merge two
+The P4Runtime server is not required to perform any optimization (e.g. merge two
 *requests* in the *batch* if one is a subset of other). As a result of this, it
 is possible for the `ReadResponse` to contain the same entity more than once. If
 performance is a concern, the P4Runtime client should handle this merging.
@@ -5375,10 +5421,10 @@ This could be from the same or multiple clients. P4Runtime is based on gRPC
 which provides a concurrent server design. A server implementation that supports
 concurrent RPC handlers may choose to maximize performance by using a
 multi-reader lock (also known as multiple-readers/single-writer lock).
-Conversely (&eg; in a single-threaded architecture), it may choose to serialize
+Conversely (e.g. in a single-threaded architecture), it may choose to serialize
 `Read` RPC processing.
 
-## Parallelism of Read and Write Requests
+==== Parallelism of Read and Write Requests
 
 A P4Runtime server may be implemented to serve at most one
 `ReadRequest` or `WriteRequest` message at a time, sequentially.  It
@@ -5416,19 +5462,20 @@ meets all of the requirements above.
 
 It is possible to meet the requirements of this specification and
 perform even more requests in parallel than that example
-implementation allows, &eg; if the server somehow determined that two
+implementation allows, e.g. if the server somehow determined that two
 `WriteRequest` messages that inserted entries to the same table could
 not affect the results of the other, they could also be performed in
 parallel.  It is not required that a P4Runtime server do this, and may
 be difficult to implement correctly.
 
 
-# `SetForwardingPipelineConfig` RPC
+=== `SetForwardingPipelineConfig` RPC
 
 A P4Runtime client may configure the P4Runtime target with a new P4 pipeline by
 invoking the `SetForwardingPipelineConfig RPC`. The request is defined as:
 
-~ Begin Proto
+[source,proto]
+----
 message SetForwardingPipelineConfigRequest {
   enum Action {
     UNSPECIFIED = 0;
@@ -5444,16 +5491,16 @@ message SetForwardingPipelineConfigRequest {
   Action action = 4;
   ForwardingPipelineConfig config = 5;
 }
-~ End Proto
+----
 
 The server is expected to perform the following checks (in this order)
 before performing the required `action`:
 
-1. If `device_id` does not match any of the devices known to the P4Runtime
+. If `device_id` does not match any of the devices known to the P4Runtime
    server or if `role` does not match any of the roles for the device, the
    server must return a `NOT_FOUND` error.
 
-2. If the client is not the primary for (`device_id`, `role`) according to
+. If the client is not the primary for (`device_id`, `role`) according to
    the `election_id` value, the server must return a `PERMISSION_DENIED` error.
 
 The action is the type of configuration action requested, it can be one of:
@@ -5477,7 +5524,7 @@ The action is the type of configuration action requested, it can be one of:
   forwarding state in the target is updated by replaying the write requests to
   the target device since the last config was saved. Config should not be
   provided for this action type. Returns a `NOT_FOUND` error if no saved config
-  is found, &ie; if no `VERIFY_AND_SAVE` action preceded this one. Returns an
+  is found, i.e. if no `VERIFY_AND_SAVE` action preceded this one. Returns an
   `INVALID_ARGUMENT` error if a config is provided with this message.
 
 * `RECONCILE_AND_COMMIT`: verifies, saves and realizes the given config, while
@@ -5493,22 +5540,23 @@ The action is the type of configuration action requested, it can be one of:
 
 The `config` field is a message of type `ForwardingPipelineConfig` that carries
 the P4Info, the opaque target-dependent forwarding-pipeline configuration data
-(&eg; generated by the P4 compiler for the target), and, optionally, the cookie
-to uniquely identify such configuration. See the [Forwarding-Pipeline
-Configuration](#sec-p4-fwd-pipe-config) section for details.
+(e.g. generated by the P4 compiler for the target), and, optionally, the cookie
+to uniquely identify such configuration. See the xref:sec-p4-fwd-pipe-config[Forwarding-Pipeline
+Configuration] section for details.
 
 A P4Runtime server running on a non-programmable device may not
-support `SetForwardingPipelineConfig` (&eg; the forwarding-pipeline
+support `SetForwardingPipelineConfig` (e.g. the forwarding-pipeline
 config is part of the device's software image, or is supplied using a
 different mechanism). In such cases, the RPC should return an
 `UNIMPLEMENTED` error.
 
-# `GetForwardingPipelineConfig` RPC
+=== `GetForwardingPipelineConfig` RPC
 
 The forwarding-pipeline configuration of the target can be retrieved by invoking
 the `GetForwardingPipelineConfig RPC`. The request is defined as:
 
-~ Begin Proto
+[source,proto]
+----
 message GetForwardingPipelineConfigRequest {
   enum ResponseType {
     ALL = 0;
@@ -5519,7 +5567,7 @@ message GetForwardingPipelineConfigRequest {
   uint64 device_id = 1;
   ResponseType response_type = 2;
 }
-~ End Proto
+----
 
 The `device_id` uniquely identifies the target P4 device. A `NOT_FOUND` error is
 returned if the `device_id` is not recognized by the P4Runtime server.
@@ -5543,11 +5591,12 @@ its value can be one of:
 
 The response contains the `ForwardingPipelineConfig` for the specified device:
 
-~ Begin Proto
+[source,proto]
+----
 message GetForwardingPipelineConfigResponse {
   ForwardingPipelineConfig config = 1;
 }
-~ End Proto
+----
 
 If a P4Runtime server is in a state where the forwarding-pipeline config is not
 known, the top-level `config` field will be unset in the response. Examples are
@@ -5569,9 +5618,10 @@ If a P4Runtime server supports both `SetForwardingPipelineConfig` as well as
 returning the `p4_device_config`, there should be read-write symmetry between
 `SetForwardingPipelineConfig` and `GetForwardingPipelineConfig` RPCs.
 
-# P4Runtime Stream Messages
+=== P4Runtime Stream Messages
 
-## Packet I/O { #sec-packet-i_o}
+[#sec-packet-i_o]
+==== Packet I/O 
 
 P4Runtime supports controller packet-in and packet-out by means of `PacketIn`
 and `PacketOut` stream messages, respectively.
@@ -5581,10 +5631,10 @@ and `PacketOut` stream messages, respectively.
 message received by the server from a client which is not allowed to send such
 messages based on its current role definition must be dropped. The server may
 also generate a `StreamMessageResponse` message with the `error` field set to
-report the error to the client. See the section on [Stream Error
-Reporting](#sec-stream-error-reporting) for more information on `error`.
+report the error to the client. See the section on xref:sec-stream-error-reporting[Stream Error
+Reporting]for more information on `error`.
 
-As introduced in the [`ControllerPacketMetadata`](#sec-controller-packet-meta)
+As introduced in the xref:sec-controller-packet-meta[`ControllerPacketMetadata`]
 section, such messages can carry arbitrary metadata specified by means of P4
 headers annotated with `@controller_header`. The expected metadata is described
 in the P4Info using the `ControllerPacketMetadata` messages.
@@ -5592,7 +5642,8 @@ in the P4Info using the `ControllerPacketMetadata` messages.
 Both `PacketIn` and `PacketOut` stream messages share the same fields and are
 defined as follows:
 
-~ Begin Proto
+[source,proto]
+----
 // Packet sent from the controller to the switch.
 message PacketOut {
   bytes payload = 1;
@@ -5610,7 +5661,7 @@ message PacketMetadata {
   uint32 metadata_id = 1;
   bytes value = 2;
 }
-~ End Proto
+----
 
 * `payload` is used to carry the full packet content, including the headers.
 
@@ -5624,13 +5675,13 @@ message PacketMetadata {
   to be consistent with what is specified in the corresponding P4Info
   `ControllerPacketMetadata.Metadata` message with the same `id`, in the
   following sense:
-  + If `ControllerPacketMetadata.Metadata.bitwidth` is set, or if
+  ** If `ControllerPacketMetadata.Metadata.bitwidth` is set, or if
     `ControllerPacketMetadata.Metadata.type_name` is set and
     `P4NewTypeSpec.translated_type.sdn_bitwidth` is set in the `P4NewTypeSpec`
     for the type name, then `PacketMetadata.value` must be a binary string of
     the specified bit width conforming to the [Bytestrings](#sec-bytestrings)
     requirements.
-  + If `ControllerPacketMetadata.Metadata.type_name` is set and
+  ** If `ControllerPacketMetadata.Metadata.type_name` is set and
     `P4NewTypeSpec.translated_type.sdn_string` is set in the
     `P4NewTypeSpec` message for the specified type name, then
     `PacketMetadata.value` can be an arbitrary SDN string subject to the
@@ -5642,7 +5693,7 @@ message PacketMetadata {
   the section on [Stream Error Reporting](#sec-stream-error-reporting) for more
   information on `error`.
 
-## Client Arbitration Update
+==== Client Arbitration Update
 
 P4Runtime's client arbitration mechanism ensures that only the current primary
 can modify state on the switch, and that the `election_id` is monotonically
@@ -5658,9 +5709,7 @@ controller first opens a bidirectional stream channel to the server via
 `StreamChannel` for each device and sends a `StreamMessageRequest` message. The
 controller populates the `MasterArbitrationUpdate` field in this message using
 its `role` and `election_id` and the `device_id` of the device, as explained
-in detail in the [Client Arbitration and Controller
-Replication](#sec-client-arbitration-and-controller-replication)
-section. For any given `(device_id, role)`, the P4Runtime server keeps track
+in detail in the xref:sec-client-arbitration-and-controller-replication[Client Arbitration and Controller Replication] section. For any given `(device_id, role)`, the P4Runtime server keeps track
 of the highest `election_id` that it has ever received. If a controller's
 `election_id` is equal to the highest `election_id` that the server has ever
 received, that controller is the primary. All other controllers are backups.
@@ -5670,12 +5719,13 @@ primary. There can be at most one primary, because for any given
 
 This invariant must be maintained across in-service software upgrades, and the
 P4Runtime server must remember the highest `election_id` after such a restart.
-However, across a [full restart](#sec-restarts), the `election_id` must be
+However, across a xref:sec-restarts[full restart], the `election_id` must be
 reset. In fact, a full restart is the only way to reset the `election_id`.
 
 The `MasterArbitrationUpdate` message is defined as follows:
 
-~ Begin Proto
+[source,proto]
+----
 message MasterArbitrationUpdate {
   uint64 device_id = 1;
   // The role for which the primary client is being arbitrated. For use-cases
@@ -5703,7 +5753,7 @@ message Role {
   // out-of-scope of P4Runtime.
   .google.protobuf.Any config = 2;
 }
-~ End Proto
+----
 
 Note that the `status` field in the `MasterArbitrationUpdate` message is not
 populated by the controller. This field is populated by the P4Runtime server
@@ -5711,9 +5761,9 @@ when it sends a `StreamMessageResponse` message back to the controller, in which
 it populates the `MasterArbitrationUpdate` message using the `device_id`,
 `role`, and `election_id` it previously received from the controller. The server
 also populates the `status` field in the `MasterArbitrationUpdate` according to
-the rules in an [earlier section](#sec-arbitration-updates).
+the rules in an xref:sec-arbitration-updates[earlier section].
 
-### Unset Election ID
+===== Unset Election ID
 
 The sender need not specify an `election_id`. If the `election_id` is
 unset, the sender's `election_id` is considered lower than any
@@ -5727,18 +5777,19 @@ Note that
 election_id : { high: 0 low: 0 }
 ```
 is different from an unset `election_id`, see
-[the section on default-valued fields](#sec-default-valued-fields).
+xref:sec-default-valued-fields[the section on default-valued fields].
 
 
-## Digest Messages
+==== Digest Messages
 
 See the [DigestEntry](#sec-digestentry) section.
 
-## Table Idle Timeout Notification { #sec-table-idle-timeout-notification}
+[#sec-table-idle-timeout-notification]
+==== Table Idle Timeout Notification 
 
 When a table supports idle timeout (as per the P4Info message), the primary
 client can specify a TTL value for each entry in the table (see
-[Idle-timeout](#sec-idle-timeout) section). If the data plane entry is not hit
+xref:sec-idle-timeout[Idle-timeout] section). If the data plane entry is not hit
 for a lapse of time greater or equal to the TTL, the P4Runtime server should,
 with best effort, generate an `IdleTimeoutNotification` message on the
 `StreamChannel` bidirectional stream to the primary client. The primary client
@@ -5776,7 +5827,8 @@ server software, the channel or the client can handle.
 Here is a reasonable pseudo-code implementation for idle timeout for table
 entries:
 
-~ Begin CPP
+[source,cpp]
+----
 IdleTimeoutStream stream;
 
 scanning_interval = 10ms;
@@ -5802,19 +5854,19 @@ while (true) {
   }
   sleep(scanning_interval);
 }
-~ End CPP
+----
 
-## Architecture-Specific Notifications
+==== Architecture-Specific Notifications
 
 P4Runtime supports streaming arbitrary Protobuf messages between the server and
-the client on `StreamChannel`, by including an `Any` Protobuf field [@ProtoAny]
+the client on `StreamChannel`, by including an `Any` Protobuf field cite:[ProtoAny]
 named `other` in both `StreamMessageRequest` and `StreamMessageResponse`. This
 enables support for architecture-specific externs which require asynchronous
-streaming of data from the server to the client, much like the [PSA `Digest`
-extern](#sec-digestentry). See section on [Extending P4Runtime for non-PSA
-Architectures](#sec-extending-p4runtime) for more information.
+streaming of data from the server to the client, much like the xref:sec-digestentry[PSA `Digest`
+extern]. See section on xref:sec-extending-p4runtime[Extending P4Runtime for non-PSA Architectures]for more information.
 
-## Stream Error Reporting { #sec-stream-error-reporting}
+[#sec-stream-error-reporting]
+==== Stream Error Reporting 
 
 The P4Runtime server can asynchronously report errors which occur when
 processing `StreamMessageRequest` messages, using the `error` message field (of
@@ -5825,7 +5877,7 @@ out-of-band mechanism to enable / disable this feature.
 The `StreamError` message has the following fields:
 
  * `canonical_code`, which must be set to the appropriate canonical error code
-   [@gRPCStatusCodes].
+   cite:[gRPCStatusCodes].
  * `message`, an optional developer-facing error message describing the error.
  * `space` and `code`, which are optional and can be used by vendors to provide
    additional details on the error. `code` is a numeric error code drawn from a
@@ -5843,7 +5895,7 @@ The `StreamError` message has the following fields:
    `PacketOut` message received on the stream channel) so that the client can
    know exactly what packet-out triggered the error.
 
-The appropriate canonical error code [@gRPCStatusCodes] should be used when
+The appropriate canonical error code cite:[gRPCStatusCodes] should be used when
 populating the `canonical_code` field. For example:
 
  * if a controller is not allowed to send a `PacketOut` message under its
@@ -5856,21 +5908,22 @@ populating the `canonical_code` field. For example:
    in P4Info, the code should be set to `INVALID_ARGUMENT`.
 
 The server may choose to assign a lower priority to error reporting messages and
-drop them first if the stream channel comes under heavy load, &eg; because of a
+drop them first if the stream channel comes under heavy load, e.g. because of a
 burst of `PacketIn` messages.
 
 Note that client arbitration errors are never reported using the `StreamError`
 message. Invalid `MasterArbitrationUpdate` messages sent by the client cause the
 stream to be terminated and the appropriate error code to be returned to the
 client immediately. See section [#sec-arbitration-updates].
-
-### Examples of `StreamError` Messages
+==== Examples of `StreamError` Messages
 
  * **Malformed packet-out metadata.** If the server receives a `PacketOut`
    message with a `metadata` field with id 7 which is not included in the P4Info
    `ControllerPacketMetadata` message for "packet_out", the server may send the
    following `StreamMessageResponse` back to the client:
-~ Begin Prototext
+
+[source,prototext]
+----
 error {
     canonical_code: 3  # INVALID_ARGUMENT
     message: "Unknown metadata field id 7."
@@ -5886,14 +5939,15 @@ error {
         # more metadata
       }
     }
-}
-~ End Prototext
+----
 
  * **Packet-out which exceeds the MTU.** If the server receives a `PacketOut`
    message which requires injecting a raw data plane packet that exceeds the MTU
    (Maximum Transmission Unit) for the egress link, the server may generate the
    following `StreamMessageResponse`:
-~ Begin Prototext
+
+[source,prototext]
+----
 error {
     canonical_code: 3  # INVALID_ARGUMENT
     message: "Packet exceeds the MTU for port."
@@ -5904,42 +5958,43 @@ error {
       # extra information to the client
     }
 }
-~ End Prototext
+----
 
-# `Capabilities` RPC
+=== `Capabilities` RPC
 
 The `Capabilities` RPC offers a mechanism through which a P4Runtime client can
 discover the capabilities of the P4Runtime server implementation. At the moment,
 the `CapabilitiesRequest` message is empty and the `CapabilitiesResponse`
 message only includes the `p4runtime_api_version` string field. This field must
-be set to the full semantic version string [@SemVer] corresponding to the
-version of the P4Runtime API implemented by the server, &eg; "1.1.0-rc.1".
+be set to the full semantic version string cite:[SemVer] corresponding to the
+version of the P4Runtime API implemented by the server, e.g. "1.1.0-rc.1".
 
 Future versions of P4Runtime may introduce more advanced capability discovery
-features. For example, P4Runtime supports three [atomicity
-modes](#sec-batch-atomicity) for `WriteRequest` batches, two of them being
+features. For example, P4Runtime supports three xref:sec-batch-atomicity[atomicity
+modes] for `WriteRequest` batches, two of them being
 optional. In the future we may decide to leverage the `CapabilitiesResponse`
 message to enable the server to report to the client which subset of these
 atomicity modes is supported.
 
 The semantic version string included in `CapabilitiesResponse` can be used by
 the client to determine which exact feature set is implemented by the server,
-since [minor releases](#sec-p4runtime-versioning) may introduce new
+since xref:sec-p4runtime-versioning[minor releases] may introduce new
 functionality. However, because the `Capabilities` RPC itself was introduced in
 version 1.1 of P4Runtime, the client should assume that any server which does
-not implement this RPC (&ie; an `UNIMPLEMENTED` error is returned by the
+not implement this RPC (i.e. an `UNIMPLEMENTED` error is returned by the
 P4Runtime service) implements an older version of the P4Runtime specification
 (1.0 or a pre-release version of 1.0).
 
-# Portability Considerations
+=== Portability Considerations
 
-## PSA Metadata Translation { #sec-psa-metadata-translation}
+[#sec-psa-metadata-translation]
+==== PSA Metadata Translation 
 
 The *Portable Switch Architecture* (PSA) defines standard metadata, whose
 data plane types are different on different PSA targets. In order to enable
 uniform programming of multiple PSA targets, a centralized remote controller may
 define its own types and numbering of such PSA standard metadata
-[@PSATranslation]. For such metadata, a translation between the controller's
+cite:[PSATranslation]. For such metadata, a translation between the controller's
 metadata values and the corresponding target-specific metadata values is
 required at runtime. In this section, we will base our discussions on port
 metadata, although the same translation principles apply to other standard PSA
@@ -5947,14 +6002,11 @@ metadata such as class of service. Since the `@p4runtime_translation` annotation
 can be applied to any user-defined type, these principles also apply to
 translated types which are not declared as part of the PSA architecture.
 
-~ Figure { #fig-psa-metadata-translation; \
-caption: "P4Runtime Metadata Translation for the Portable Switch Architecture" }
-![psa-metadata-translation]
-~
-[psa-metadata-translation]: build/psa-metadata-translation.[svg,png] \
-{ height: 7cm; page-align: here }
+.P4Runtime Metadata Translation for the Portable Switch Architecture
+[#fig-psa-metadata-translation]
+image::psa-metadata-translation..png[]
 
-Figure [#fig-psa-metadata-translation] illustrates a motivating example,
+Figure <<#fig-psa-metadata-translation>> illustrates a motivating example,
 where a centralized controller is controlling two P4Runtime targets in a fabric.
 Switch 1 and Switch 2 use different PSA devices, each defining its own port type
 and number space. In this example, Switch 1 uses a device with 9-bit space for
@@ -5965,26 +6017,28 @@ numbers to a target's 9-bit or 10-bit port numbers is input to the switch via
 the non-forwarding switch config data that is delivered separately to the
 switch.
 
-### Translation of Port Numbers { #sec-translation-of-port-numbers}
+[#sec-translation-of-port-numbers]
+==== Translation of Port Numbers 
 
 In order to support the above SDN use case, P4Runtime requires translation of
 port metadata values between the controller's space and the PSA device's space
 as needed. Such translation is enabled by identifying a P4 entity (match field,
 action parameter, controller-header field or other) as being a PSA port metadata
 type. For this purpose, PSA defines the port metadata field type using special
-[user-defined P4 types](#sec-user-defined-types), namely `PortId_t` and
+xref:sec-user-defined-types[user-defined P4 types], namely `PortId_t` and
 `PortIdInHeader_t`, instead of standard P4 bitstrings. The P4Info entries for
 all P4 entities whose type is one of the special PSA port types use a
 controller-defined 32-bit type instead of the data plane bitwidth defined in the
 P4 program. The following PSA port metadata types are defined in *psa.p4* for
 the PSA device in Switch 1.
 
-~ Begin P4Example
+[source,p4]
+----
 @p4runtime_translation("p4.org/psa/v1/PortId_t", 32)
 type bit<9> PortId_t;
 @p4runtime_translation("p4.org/psa/v1/PortIdInHeader_t", 32)
 type bit<32> PortIdInHeader_t;
-~ End P4Example
+----
 
 The first argument to the `@p4runtime_translation` annotation is a URI that
 indicates to the P4Runtime server which numerical mapping --- provided by the
@@ -5998,7 +6052,8 @@ ports in the device-specific port number space. P4Runtime reserves
 device-independent and controller-specific 32-bit constants for the CPU port and
 the recirculation port as follows:
 
-~ Begin Proto
+[source,proto]
+----
 enum SdnPort {
   SDN_PORT_UNKNOWN = 0;
 
@@ -6013,7 +6068,7 @@ enum SdnPort {
   SDN_PORT_RECIRCULATE = 0xfffffffa;
   SDN_PORT_CPU = 0xfffffffd;
 }
-~ End Proto
+----
 
 The switch config will map `SDN_PORT_RECIRCULATE` and `SDN_PORT_CPU` --- as well
 as any SDN port number corresponding to a "regular" front-panel port --- to the
@@ -6023,12 +6078,13 @@ perform the translation.
 The sub-sections below detail the translation mechanics for different usage of
 PSA port types in P4 programs.
 
-### Translation of Packet-IO Header Fields
+===== Translation of Packet-IO Header Fields
 
 Port type fields can be part of header types. For example, ports may be part of
 Packet IO headers, as in the following example:.
 
-~ Begin P4Example
+[source,p4]
+----
 @controller_header("packet_out")
 header PacketOut_t {
   PortIdInHeader_t egress_port;
@@ -6038,7 +6094,7 @@ header PacketOut_t {
 header PacketIn_t {
   PortIdInHeader_t ingress_port;
 }
-~ End P4Example
+----
 
 The header-level annotation `@controller_header` is a standard P4Runtime
 annotation that identifies a header type for a controller packet-out or
@@ -6064,12 +6120,13 @@ config. The server will then insert the translated controller-specific value in
 the packet-in metadata fields before sending the packet over the stream channel
 to the controller.
 
-### Translation of Match Fields
+===== Translation of Match Fields
 
 Port type entities, particularly ingress and egress port standard metadata, may
 be used as match fields in a P4 table's match key as shown in the example below:
 
-~ Begin P4Example
+[source,p4]
+----
 table t {
   key = {
     istd.ingress_port: exact;  // PSA standard metadata ingress port
@@ -6078,7 +6135,7 @@ table t {
     drop;
   }
 }
-~ End P4Example
+----
 
 Table `t` has an exact match on PSA standard metadata ingress port
 (`istd.ingress_port`). Since the field is of type `PortId_t`, the P4Info
@@ -6099,12 +6156,13 @@ require that for these match kinds the port match be either *de facto* "exact"
 (0xffffffff mask for `TERNARY`, prefix-length of 32 for `LPM`, or same low and
 high bounds for `RANGE`) or "don't care".
 
-### Translation of Action Parameters
+===== Translation of Action Parameters
 
 `PortId_t` type parameters can be part of a P4 action definition as shown in the
 example below:
 
-~ Begin P4Example
+[source,p4]
+----
 action a(PortId_t p) {
   istd.egress_port = p;  // PSA standard metadata egress port
 }
@@ -6117,7 +6175,7 @@ table t {
     a;
   }
 }
-~ End P4Example
+----
 
 The controller may write entries in table `t` with action `a` to set the egress
 port as shown in the P4 code above. The action parameter `p` is of type
@@ -6127,7 +6185,7 @@ translation is required for this parameter. The P4Runtime server will use the
 switch configuration to translate action parameter values between the controller
 and the target device.
 
-### Port Translation for PSA Extern APIs
+===== Port Translation for PSA Extern APIs
 
 The P4Runtime API for action selectors supports specifying a watch field per
 member in an action profile group that is programmed in a selector. This field
@@ -6147,25 +6205,27 @@ representation of the port(s). The P4Runtime server will translate these SDN
 ports to device-specific port numbers for multicasting and cloning in the data
 plane.
 
-### Using Port as an Index to a Register, Indirect Counter or Indirect Meter
+===== Using Port as an Index to a Register, Indirect Counter or Indirect Meter
 
 P4Runtime supports using a translated value (`PortId_t` or any other translated
 type for which the underlying built-in type is `bit<W>`) as an index to a
 register, indirect counter, or indirect meter.
 
-~ Begin P4Example
+[source,p4]
+----
 Counter<bit<32> /* counter entry type */, PortId_t /* index type */>(
   32w1024, PSA_CounterType_t.PACKETS) counter;
 action a(PortId_t p) {
   istd.egress_port = p;  // PSA standard metadata egress port
   counter.count(p);
 }
-~ End P4Example
+----
 
 This P4 Counter declaration will translate into the following entry in the
 P4Info messsage:
 
-~ Begin Prototext
+[source,prototext]
+----
 counters {
   preamble {
     id: 0x12000001
@@ -6178,17 +6238,18 @@ counters {
     name: "PortId_t"
   }
 }
-~ End Prototext
+----
 
 The controller may read and write counter values from indexed counter `counter`
 using SDN port numbers as indices, and not device-specific port numbers. The
 `index_type_name` field in the P4Info message is a signal to the P4Runtime
 server that translation is required.
 
-# P4Runtime Versioning { #sec-p4runtime-versioning}
+[#sec-p4runtime-versioning]
+=== P4Runtime Versioning 
 
 P4Runtime follows the Google guidelines for versioning cloud APIs
-[@APIVersioning]. We use a `MAJOR.MINOR.PATCH` style version number scheme and
+cite:[APIVersioning]. We use a `MAJOR.MINOR.PATCH` style version number scheme and
 we increment the:
 
 * `MAJOR` version when we make incompatible API changes,
@@ -6203,13 +6264,13 @@ different Protobuf packages, `p4` depends on `p4.config` and is not meant to be
 used without it, which is why both packages use the same versioning scheme and
 the same versioning cadence.
 
-As recommended in [@APIVersioning], we may consider using pre-GA release
+As recommended in cite:[APIVersioning], we may consider using pre-GA release
 suffixes (such as *alpha* or *beta*) in the Protobuf package name for future
 major versions, although we have chosen not to do so when developing version 1
 (v1).
 
 Within a major version, the API must be evolved in a Protobuf
-backwards-compatible manner. [@APIVersioningBackwardsCompatibility] describes
+backwards-compatible manner. cite:[APIVersioningBackwardsCompatibility] describes
 what constitute a backwards-compatible change. We expect `MAJOR` version bumps
 to be a **rare** event.
 
@@ -6221,10 +6282,11 @@ attempting to connect to the corresponding service. We may consider including a
 P4Runtime RPC to query minor + patch version numbers in future releases.
 
 All versions of P4Runtime, including pre-release versions, are tagged in the
-P4Runtime Github repository [@P4RuntimeRepo] and the version label follows
-semantic versioning rules [@SemVer].
+P4Runtime Github repository cite:[P4RuntimeRepo] and the version label follows
+semantic versioning rules cite:[SemVer].
 
-# Extending P4Runtime for non-PSA Architectures { #sec-extending-p4runtime}
+[#sec-extending-p4runtime]
+=== Extending P4Runtime for non-PSA Architectures 
 
 P4Runtime includes native support for PSA programs and in particular support for
 runtime control of PSA extern instances. While the definition of Protobuf
@@ -6247,7 +6309,7 @@ as the major version number for the P4Runtime version they "extend".
 For the remainder of this section, we will refer to these two files as
 *p4info-ext* and *p4runtime-ext* respectively.
 
-## Extending P4Runtime for Architecture-Specific Externs
+==== Extending P4Runtime for Architecture-Specific Externs
 
 Each P4 architecture can define its own set of extern types. Controlling them at
 runtime requires defining new Protobuf messages in both *p4info-ext* and
@@ -6255,79 +6317,82 @@ runtime requires defining new Protobuf messages in both *p4info-ext* and
 that the new architecture we are trying to support in P4Runtime includes the
 following extern definition, which we will use as a running example:
 
-~ Begin P4Example
+[source,p4]
+----
 // T must be a bit<W> type, it indicates the width of each counter cell
 extern MyNewPacketCounter<T> {
   counter(bit<32> size);
   increment(in bit<32> index);
 }
-~ End P4Example
+----
 
-### Extending the P4Info message
+===== Extending the P4Info message
 
 * Id prefixes `0x81` through `0xfe` are reserved for architecture-specific
   externs. It is recommended that *p4info-ext* include a `P4Ids` message based
-  on the one in p4info.proto that the P4 compiler can refer to when [assigning
-  IDs](#sec-id-allocation) to each extern instance.
+  on the one in p4info.proto that the P4 compiler can refer to when xref:sec-id-allocation[assigning IDs] to each extern instance.
 
-~ Begin Proto
+[source,proto]
+----
 message P4Ids {
   enum Prefix {
     UNSPECIFIED = 0;
     MY_NEW_PACKET_COUNTER = 0x81;
   }
 }
-~ End Proto
+----
 
 * *p4info-ext* should include a Protobuf message definition for every extern
   type that can be controlled at runtime. For every extern instance of this
   type, the compiler will generate an instance of this Protobuf message and
   embed it appropriately in the corresponding
-  [`p4.config.v1.ExternInstance`](#sec-p4info-extern) message as the `info`
-  field, which is of type `Any` [@ProtoAny].
+  xref:sec-p4info-extern[`p4.config.v1.ExternInstance`] message as the `info`
+  field, which is of type `Any` cite:[ProtoAny].
 
-~ Begin Proto
+[source,proto]
+----
 message MyNewPacketCounter {
   // corresponds to the T type parameter in the P4 extern definition
   p4.config.v1.P4DataTypeSpec type_spec = 1;
   // constructor argument
   int64 size = 2;
 }
-~ End Proto
+----
 
-### Extending the P4Runtime Service
+===== Extending the P4Runtime Service
 
 Just like *p4info-ext*, *p4runtime-ext* should include a Protobuf message
 definition for every extern type that can be controlled at runtime. This message
 should include the extern-specific parameters defining the read or write
 operation to be performed by the P4Runtime server on the corresponding extern
 instance. Instances of this architecture-specific message are meant to be
-embedded in an [`ExternEntry`](#sec-extern-entry) message generated by the
+embedded in an xref:sec-extern-entry[`ExternEntry`] message generated by the
 P4Runtime client.
 
 Here is a possible Protobuf message for our `MyNewPacketCounter` P4 extern:
-~ Begin Proto
+[source,proto]
+----
 // This message enables reading / writing data to the counter at the provided
 // index
 message MyNewPacketCounter {
   int64 index = 1;
   p4.v1.P4Data data = 2;
 }
-~ End Proto
+----
 
 P4Runtime also supports streaming arbitrary Protobuf messages between the server
-and the client, by including an `Any` Protobuf field [@ProtoAny] named `other`
+and the client, by including an `Any` Protobuf field cite:[ProtoAny] named `other`
 in both `p4.v1.StreamMessageRequest` and
 `p4.v1.StreamMessageResponse`. Architectures that wish to leverage this support
 should define the appropriate Protobuf messages for this bidirectional streaming
 in *p4runtime-ext* and embed instances of these messages in
 `p4.v1.StreamMessageRequest` and `p4.v1.StreamMessageResponse` as appropriate.
 
-## Architecture-Specific Table Extensions
+==== Architecture-Specific Table Extensions
 
-### New Match Types
+===== New Match Types
 
-An architecture may introduce new table match types [@P4MatchTypes]. P4Runtime
+An architecture may introduce new table match types cite:[P4MatchTypes]. P4Runtime
 accounts for this by providing the following hooks:
 
 * The `match` field in `p4.config.v1.MatchField` (p4info.proto) is a `oneof`
@@ -6336,7 +6401,7 @@ accounts for this by providing the following hooks:
   string.
 
 * The `field_match_type` field in `p4.v1.FieldMatch` (p4runtime.proto) is a
-  `oneof` which includes an `Any` Protobuf message [@ProtoAny] field
+  `oneof` which includes an `Any` Protobuf message cite:[ProtoAny] field
   (`other`). *p4info-ext* should include a Protobuf message definition for each
   architecture-specific match type, which can be used to encode values for match
   key elements which use this match type type in the P4 table
@@ -6344,30 +6409,30 @@ accounts for this by providing the following hooks:
   `other` field, which can then be decoded by the P4Runtime server using the
   match type name included in P4Info.
 
-### New Table Properties
+===== New Table Properties
 
 An architecture may introduce additional table properties
-[@P4TableProperties]. In some instances, it can be desirable to include the
+cite:[P4TableProperties]. In some instances, it can be desirable to include the
 information contained in table properties in P4Info, which is why the
 `p4.config.v1.Table` message includes the `other_properties` `Any` Protobuf
-field [@ProtoAny]. At the moment, there is not any mechanism to extend the
+field cite:[ProtoAny]. At the moment, there is not any mechanism to extend the
 `p4.v1.TableEntry` message based on the value of architecture-specific table
 properties, but we may include on in future versions of the API.
 
-# Known Limitations of Current P4Runtime Version
+=== Known Limitations of Current P4Runtime Version
 
 * `FieldMatch`, action `Param`, and controller packet metadata fields only
-  support unsigned bitstrings, &ie; values of one of the following types (not
+  support unsigned bitstrings, i.e. values of one of the following types (not
   the more general `P4Data`):
-  * `bit<W>`
-  * `bool`.  Note that as far as the `P4Info` message contents and
+  ** `bit<W>`
+  ** `bool`.  Note that as far as the `P4Info` message contents and
     thus controller software is concerned, such fields of type `bool`
     will be indistinguishable from those that have been declared with
     type `bit<1>`.  P4Runtime server software will automatically
     perform any conversion needed between the type `bit<1>` values in
     P4Runtime messages and the data plane representation.
-  * an `enum` with underlying type `bit<W>`
-  * a `type` or `typedef` with an underlying type that is one of the above (or
+  ** an `enum` with underlying type `bit<W>`
+  ** a `type` or `typedef` with an underlying type that is one of the above (or
     in general a "chain" of `type` and/or `typedef` that eventually ends with
     one of the types above)
 
@@ -6387,11 +6452,12 @@ properties, but we may include on in future versions of the API.
   in particular, there is no way for a client to query the supported minor +
   patch version numbers.
 
-# Appendix { @h1:"A"}
+[@h1:"A"]
+=== Appendix 
 
-## Revision History
+==== Revision History
 
-### Changes in v1.4.0
+===== Changes in v1.4.0
 
 * Add a `Type` field to the `MeterSpec` message allowing users to restrict the
   type of meters that can be used for a table and a new `eburst` field to the
@@ -6409,7 +6475,7 @@ properties, but we may include on in future versions of the API.
   not set yet).
 * Clarify that for updates of type `INSERT`, error codes other than
   `INVALID_ARGUMENT` can be returned when applicable.
-* Enable C++ Arena Allocation [@ArenaAllocation] by default in p4runtime.proto.
+* Enable C++ Arena Allocation cite:[ArenaAllocation] by default in p4runtime.proto.
 * Add support for string role identifiers and deprecate integer role
   identifiers.
 * Add support for specifying a role in `ReadRequest` messages: if present, only
@@ -6428,7 +6494,7 @@ properties, but we may include on in future versions of the API.
 * Add a `selector_size_semantics` field to the `ActionProfile` message
   in P4Info.
 
-### Changes in v1.3.0
+===== Changes in v1.3.0
 
 * Add IANA assigned TCP port, 9559, to P4Runtime server discussion.
 * Move "Security considerations" section to P4Runtime server discussion.
@@ -6439,10 +6505,10 @@ properties, but we may include on in future versions of the API.
 * Clarify that source locations for annotations are optional in the P4Info
   message.
 
-### Changes in v1.2.0
+===== Changes in v1.2.0
 
 * Add new `OPTIONAL` match kind. At the moment, `OPTIONAL` is only supported by
-  the v1model architecture [@v1model], and not by PSA. It will eventually be
+  the v1model architecture cite:[v1model], and not by PSA. It will eventually be
   included in the core P4 language.
 * Add support in P4Info for structured annotations, which are used to annotate
   objects with key-value lists or expression lists.
@@ -6459,7 +6525,7 @@ properties, but we may include on in future versions of the API.
 * Add optional P4 source locations to both structured and unstructured
   annotations.
 
-### Changes in v1.1.0
+===== Changes in v1.1.0
 
 * Major overhaul of master-arbitration: while the Protobuf messages did not
   change, the state machine that the server needs to implement is significantly
@@ -6484,9 +6550,9 @@ properties, but we may include on in future versions of the API.
 * Document that `@p4runtime_translation` need only be supported when applied to
   type declarations in P4.
 
-## P4 Annotations
+==== P4 Annotations
 
-Table [#tab-p4-annotations] lists P4~16~ annotations introduced primarily for
+Table <<#tab-p4-annotations>> lists P4~16~ annotations introduced primarily for
 the purpose of adding features for the P4Runtime API.
 
 ~ TableFigure { #tab-p4-annotations; \
@@ -6511,12 +6577,14 @@ the purpose of adding features for the P4Runtime API.
 +----------------------------+---------------------------------------+
 ~
 
-## A More Complex Value Set Example { #sec-value-set-example}
+[#sec-value-set-example]
+=== A More Complex Value Set Example 
 
 This section includes a more complex Value Set example, with multiple matches of
 different kinds.
 
-~ Begin P4Example
+[source,p4]
+----
 struct match_t {
   bit<8> f8;
   @match(ternary) bit<16> f16;
@@ -6524,12 +6592,13 @@ struct match_t {
 }
 @id(1) value_set<match_t>(4) pvs;
 select ({ hdr.f8, hdr.f16, hdr.f32 }) { /* ... */ }
-~ End P4Example
+----
 
 This P4 Value Set declaration will translate into the following entry in the
 P4Info messsage:
 
-~ Begin Prototext
+[source,prototext]
+----
 value_sets {
   preamble {
     id: 0x03000001
@@ -6555,12 +6624,13 @@ value_sets {
   }
   size: 4
 }
-~ End Prototext
+----
 
 A P4Runtime client can set the membership for this Value Set with `WriteRequest`
 messages similar to this one:
 
-~ Begin Prototext
+[source,prototext]
+----
 type: MODIFY
 entity {
   value_set_entry {
@@ -6592,21 +6662,20 @@ entity {
     }
   }
 }
-~ End Prototext
+----
 
-
-## Guidelines for Implementations
+=== Guidelines for Implementations
 
 This section contains practical advice for implementing P4Runtime clients and
 servers.
 
-### gRPC Metadata Maximum Size
+==== gRPC Metadata Maximum Size
 
 In gRPC, the status of a RPC request is sent as metadata, whose size is limited
 by the `grpc.max_metadata_size` gRPC channel argument.  By default, this limit
 is 8KB, which can be a problem for the `Write` P4Runtime RPC.  The `Write` RPC
 returns an individual error for every item in a batch (see Section
-[#sec-write-rpc]), which can quickly result in a status size over 8KB.  In that
+<<#sec-write-rpc>>), which can quickly result in a status size over 8KB.  In that
 case, the gRPC server would not send the status, but instead send a
 `RESOURCE_EXHAUSTED` error, without any of the individual errors.
 
@@ -6627,7 +6696,7 @@ arguments.SetInt(GRPC_ARG_MAX_METADATA_SIZE, 8192 + MAX_UPDATES_PER_WRITE*100);
 return grpc::CreateCustomChannel(address, credentials, arguments);
 ~ End CPP
 
-### gRPC Server Maximum Receive Message Size
+==== gRPC Server Maximum Receive Message Size
 
 At the time of writing, the default maximum receive message size in gRPC is 4MB
 --- while the default maximum send message size is unlimited. This can be a
@@ -6642,14 +6711,16 @@ possible values of `p4_device_config` for their target(s). This can be done by
 setting the `grpc.max_receive_message_length` when building the gRPC server.
 
 For example, in C++, one can set the maximum receive message size as follows:
-~ Begin CPP
+
+[source,cpp]
+----
 const int MAX_RECEIVE_MESSAGE_SIZE = 128 * 1024 * 1024;  // 128MB
 ::grpc::ServerBuilder server_builder;
 builder.AddListeningPort(/*...*/);
 builder.RegisterService(/*...*/);  // register P4Runtime service
 builder.SetMaxReceiveMessageSize(MAX_RECEIVE_MESSAGE_SIZE);
 builder.BuildAndStart();
-~ End CPP
+----
 
 On the client side, we recommend that P4Runtime clients do not use `Write`
 batches larger than the default maximum receive message size (4MB) --- in case
@@ -6658,14 +6729,15 @@ clients are aware that the server is using a larger maximum receive message
 size. The gRPC server running the P4Runtime service must not set the maximum
 receive message size to a value smaller than the default (4MB).
 
-## P4Runtime Entries files { #sec-entries-files }
+[#sec-entries-files]
+==== P4Runtime Entries files 
 
-The open source P4 compiler `p4c` [@p4c] implements an option to
-generate an "entries file", &ie; a file that contains all table
+The open source P4 compiler `p4c` cite:[p4c] implements an option to
+generate an "entries file", i.e. a file that contains all table
 entries declared via the `entries` table property within the program.
 
 An example P4~16~ program that can be used to demonstrate this
-capability is `table-entries-ternary-bmv2.p4` [@p4cTestProgramForConstEntries]:
+capability is `table-entries-ternary-bmv2.p4` cite:[p4cTestProgramForConstEntries]:
 
     git clone https://github.com/p4lang/p4c
     cd p4c/testdata/p4_16_samples
@@ -6703,7 +6775,7 @@ containing the data for one table entry.
 Note that if a P4Runtime client attempted to send a `WriteRequest` to
 a P4Runtime server with the contents of the entries file, the server
 must return an error for each entry that has `is_const` true, as
-described in Section [#sec-table-entry].
+described in Section <<#sec-table-entry>>.
 
 [bibliography]
 == References

--- a/p4runtime-spec-next/resources/theme/references.bib
+++ b/p4runtime-spec-next/resources/theme/references.bib
@@ -151,6 +151,11 @@
     url = "https://tools.ietf.org/html/rfc2698"
 }
 
+@ONLINE { RFC2697,
+    title = "A Single Rate Three Color Marker",
+    url = "https://tools.ietf.org/html/rfc2697"
+}
+
 @ONLINE { P4MatchTypes,
     title = "Match types in P4",
     url = "https://p4.org/p4-spec/docs/P4-16-v1.2.1.html#sec-match-kind-type"


### PR DESCRIPTION
The Asciidoc syntax adaptation is complete, and the first PDF draft is available. However: 

1. Compilation warnings:
   - RFC2697 is not in the bib
   - Some section IDs are referenced using xref within the document, but they are not defined.

2. Some styles still need to be adjusted:
    - Tables
    - Bullet lists
    - Code blocks
